### PR TITLE
Add Python Explorer to resource kit guides

### DIFF
--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -187,6 +187,24 @@
                         </div>
                     </a>
 
+                    <!-- Card 7 -->
+                    <a href="https://jamditis.github.io/python-explorer/" target="_blank" rel="noopener noreferrer" class="group block border border-white/10 bg-panel hover:border-ice transition-all duration-300 relative overflow-hidden">
+                        <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-ice">
+                            <i data-lucide="library" class="w-6 h-6"></i>
+                        </div>
+                        <div class="p-6">
+                            <div class="text-xs text-ice font-mono mb-3">:: LIBRARY_DATABASE</div>
+                            <h4 class="font-display text-xl text-white font-bold mb-3 group-hover:text-ice transition-colors">Python Explorer</h4>
+                            <p class="text-sm text-gray-500 font-mono leading-relaxed">
+                                Interactive directory of Python libraries across 8+ domains. Browse, search, and compare packages for your newsroom projects.
+                            </p>
+                        </div>
+                        <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-ice transition-colors">
+                            <span>EXPLORE_DB</span>
+                            <span>↗</span>
+                        </div>
+                    </a>
+
                 </div>
             </section>
 


### PR DESCRIPTION
Added new card in guides section linking to Python Explorer
(https://jamditis.github.io/python-explorer/) - an interactive
directory of Python libraries across 8+ domains (Web, Data Science,
ML, DevOps, Automation, Design, Media, Visualization).

Features:
- Ice (blue) accent color for visual distinction
- Library icon representing package database
- External link with target="_blank"
- Description tailored for newsroom use cases