### PR TITLE
Explore new Claude Code CLI features with subagents

### DIFF
--- a/.claude/hooks/json-validator.md
+++ b/.claude/hooks/json-validator.md
@@ -1,0 +1,73 @@
+---
+hooks:
+  - type: PostToolUse
+    tool: [Edit, Write]
+    command: |
+      FILE="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
+
+      # Only validate JSON files in llm-advisor/data
+      if [[ "$FILE" == *llm-advisor/data/*.json ]]; then
+        echo ""
+        echo "🔍 Validating JSON: $(basename "$FILE")"
+
+        # Check JSON syntax
+        if node -e "JSON.parse(require('fs').readFileSync('$FILE', 'utf8'))" 2>/dev/null; then
+          echo "✅ JSON syntax valid"
+
+          # Additional schema checks based on file type
+          FILENAME=$(basename "$FILE")
+          case "$FILENAME" in
+            decision-tree.json)
+              # Check for required 'start' node
+              if node -e "const d=JSON.parse(require('fs').readFileSync('$FILE','utf8')); if(!d.start)process.exit(1)" 2>/dev/null; then
+                echo "✅ Has 'start' node"
+              else
+                echo "⚠️  Missing required 'start' node"
+              fi
+              ;;
+            model-info.json)
+              # Check for required model entries
+              MODELS=$(node -e "console.log(Object.keys(JSON.parse(require('fs').readFileSync('$FILE','utf8'))).join(', '))" 2>/dev/null)
+              echo "📋 Models defined: $MODELS"
+              ;;
+            case-studies.json)
+              # Count case studies
+              COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$FILE','utf8')).length)" 2>/dev/null)
+              echo "📋 Case studies: $COUNT"
+              ;;
+          esac
+        else
+          echo "❌ INVALID JSON SYNTAX"
+          echo "Fix the JSON before continuing"
+          exit 1
+        fi
+        echo ""
+      fi
+---
+
+# JSON Validator Hook
+
+Automatically validates LLM Advisor JSON data files after modification.
+
+## Validated Files
+
+Located in `resource-kit/docs/llm-advisor/data/`:
+
+| File | Validation |
+|------|------------|
+| `decision-tree.json` | Syntax + 'start' node required |
+| `model-info.json` | Syntax + lists defined models |
+| `case-studies.json` | Syntax + counts entries |
+| `tool-comparison.json` | Syntax only |
+| `best-practices.json` | Syntax only |
+| `changelog.json` | Syntax only |
+
+## Error Handling
+
+- **Valid JSON**: Shows confirmation + schema-specific info
+- **Invalid JSON**: Blocks and displays error
+
+## Exit Codes
+
+- `0` - Valid JSON, proceed normally
+- `1` - Invalid JSON, blocks further processing

--- a/.claude/hooks/model-name-validator.md
+++ b/.claude/hooks/model-name-validator.md
@@ -1,0 +1,55 @@
+---
+hooks:
+  - type: PostToolUse
+    tool: Edit
+    command: |
+      FILE="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
+
+      # Only check relevant files
+      if [[ "$FILE" == *.json ]] || [[ "$FILE" == *.html ]] || [[ "$FILE" == *.md ]]; then
+        # Check for outdated model names
+        OUTDATED=$(grep -nE "Claude 4 Opus|Claude 3|GPT-4o|GPT-4|Gemini 2\.|Gemini 1\." "$FILE" 2>/dev/null || true)
+
+        if [ -n "$OUTDATED" ]; then
+          echo ""
+          echo "⚠️  OUTDATED MODEL NAMES DETECTED"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "$OUTDATED"
+          echo ""
+          echo "📋 Current names to use:"
+          echo "   • Claude 4.5 Opus"
+          echo "   • Claude 4.5 Sonnet"
+          echo "   • Gemini 3.0 Pro"
+          echo "   • Gemini 3.0 Flash"
+          echo "   • GPT 5.1 / Codex (GPT 5.1)"
+          echo ""
+        fi
+      fi
+---
+
+# Model Name Validator Hook
+
+Automatically checks edited files for outdated AI model names.
+
+## Correct Model Names
+
+| Model | Correct Name |
+|-------|-------------|
+| Claude best | Claude 4.5 Opus |
+| Claude fast | Claude 4.5 Sonnet |
+| Gemini best | Gemini 3.0 Pro |
+| Gemini fast | Gemini 3.0 Flash |
+| OpenAI code | Codex (GPT 5.1) |
+| OpenAI chat | GPT 5.1 |
+
+## Outdated Names (flagged)
+
+- Claude 4 Opus, Claude 3.x
+- GPT-4o, GPT-4
+- Gemini 2.x, Gemini 1.x
+
+## Files Checked
+
+- `.json` - LLM Advisor data files
+- `.html` - Web pages
+- `.md` - Documentation and templates

--- a/.claude/hooks/session-start.md
+++ b/.claude/hooks/session-start.md
@@ -1,0 +1,57 @@
+---
+hooks:
+  - type: UserPromptSubmit
+    once: true
+    command: |
+      echo ""
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "  🎨 AMDITIS RESOURCE KIT - DEV SESSION"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo ""
+
+      # Check local server
+      if curl -s http://localhost:8000 > /dev/null 2>&1; then
+        echo "✅ Local server: http://localhost:8000"
+      else
+        echo "💡 Start server: cd resource-kit/docs && python -m http.server 8000"
+      fi
+
+      # Check deployment status
+      echo ""
+      if command -v gh &> /dev/null; then
+        LAST_RUN=$(gh run list --limit 1 --json status,conclusion,displayTitle -q '.[0] | "\(.status): \(.displayTitle)"' 2>/dev/null)
+        if [ -n "$LAST_RUN" ]; then
+          echo "📦 Last deploy: $LAST_RUN"
+        fi
+      fi
+
+      echo ""
+      echo "Quick commands:"
+      echo "  /plan     - Plan complex features"
+      echo "  /rename   - Name this session"
+      echo "  /stats    - View usage stats"
+      echo ""
+---
+
+# Session Start Hook
+
+This hook runs once at the start of each Claude Code session in the Amditis Resource Kit project.
+
+## What it does
+
+1. Displays development session banner
+2. Checks if local development server is running
+3. Shows last GitHub Pages deployment status
+4. Provides quick command reminders
+
+## Customization
+
+To disable this hook, add to `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "disabled": ["session-start"]
+  }
+}
+```

--- a/.claude/hooks/theme-validator.md
+++ b/.claude/hooks/theme-validator.md
@@ -1,0 +1,77 @@
+---
+hooks:
+  - type: PreToolUse
+    tool: Edit
+    command: |
+      NEW_CONTENT="${CLAUDE_TOOL_INPUT_NEW_STRING:-}"
+      FILE="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
+
+      # Only check CSS and HTML files
+      if [[ "$FILE" == *.css ]] || [[ "$FILE" == *.html ]]; then
+        # Check for forbidden light theme classes
+        FORBIDDEN=$(echo "$NEW_CONTENT" | grep -oE "bg-light-[a-z]+|dark:bg-dark-[a-z]+|bg-accent-[a-z]+" || true)
+
+        if [ -n "$FORBIDDEN" ]; then
+          echo ""
+          echo "🚫 BLOCKED: Light theme classes detected"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "Found: $FORBIDDEN"
+          echo ""
+          echo "📋 Use Amditis dark theme classes instead:"
+          echo ""
+          echo "Backgrounds:"
+          echo "   bg-void     (#050505) - deepest black"
+          echo "   bg-panel    (#0a0a0a) - cards/panels"
+          echo "   bg-surface  (#111111) - interactive"
+          echo ""
+          echo "Text:"
+          echo "   text-chrome (#e8e8e8) - primary"
+          echo "   text-gray-400/500/600 - secondary"
+          echo ""
+          echo "Accents:"
+          echo "   text-acid / bg-acid   (#c8ff00) - primary green"
+          echo "   text-ice / bg-ice     (#00f0ff) - blue"
+          echo "   text-signal / bg-signal (#ff3366) - warning"
+          echo ""
+          exit 1
+        fi
+      fi
+---
+
+# Amditis Theme Validator Hook
+
+Prevents accidental use of light theme classes in CSS/HTML files.
+
+## Blocked Patterns
+
+- `bg-light-*` - Light background classes
+- `dark:bg-dark-*` - Dark mode toggle classes
+- `bg-accent-*` - Generic accent classes
+
+## Amditis Theme System
+
+This is a single dark theme - no light/dark toggle.
+
+### Backgrounds
+| Class | Hex | Use |
+|-------|-----|-----|
+| `bg-void` | #050505 | Deepest black |
+| `bg-panel` | #0a0a0a | Cards/panels |
+| `bg-surface` | #111111 | Interactive |
+
+### Text
+| Class | Hex | Use |
+|-------|-----|-----|
+| `text-chrome` | #e8e8e8 | Primary |
+| `text-gray-400` | - | Secondary |
+| `text-gray-500` | - | Tertiary |
+
+### Accents
+| Class | Hex | Use |
+|-------|-----|-----|
+| `text-acid` | #c8ff00 | Primary accent |
+| `text-ice` | #00f0ff | Secondary accent |
+| `text-signal` | #ff3366 | Warning/error |
+
+### Borders
+Always use: `border-white/10` or `border-white/5`

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,32 +2,61 @@
   "permissions": {
     "allow": [
       "Bash(head:*)",
-      "Bash(powershell -Command \"& {(Get-Content ''C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\context\\Vibe coding starter guide for newsrooms (12_10_2025 9：02：40 PM).html'' -Raw) -replace ''<[^>]+>'', '' '' -replace ''\\s+'', '' '' | Select-Object -First 1}\")",
-      "Bash(powershell -Command \"& {(Get-Content ''C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\context\\Vibe coding starter guide for newsrooms (12_10_2025 9：02：40 PM).html'' -Raw) | Select-String -Pattern ''<h[1-3][^>]*>.*?</h[1-3]>'' -AllMatches | ForEach-Object { $_Matches.Value } | ForEach-Object { $_-replace ''<[^>]+>'', '''' }}\")",
-      "Bash(powershell -Command \"& {(Get-Content ''C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\context\\LLM journalism tool advisor (12_10_2025 9：03：07 PM).html'' -Raw) | Select-String -Pattern ''<h[1-3][^>]*>.*?</h[1-3]>'' -AllMatches | ForEach-Object { $_Matches.Value } | ForEach-Object { $_-replace ''<[^>]+>'', '''' }}\")",
-      "Skill(frontend-design:frontend-design)",
-      "Bash(powershell -Command \"Get-Content ''C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\context\\Vibe coding starter guide for newsrooms (12_10_2025 9：02：40 PM).html'' -Raw | Select-String -Pattern '':root\\s*\\{[^}]+\\}'' -AllMatches\")",
-      "Bash(powershell -Command \"(Get-Content ''C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\context\\Vibe coding starter guide for newsrooms (12_10_2025 9：02：40 PM).html'' -Raw).Substring(0, 8000)\")",
       "Bash(powershell:*)",
       "Bash(git init:*)",
       "Bash(git add:*)",
-      "Bash(gh auth status:*)",
-      "Bash(git commit -m \"$(cat <<''EOF''\nInitial commit: CCM AI tools resource kit\n\nIncludes:\n- Vibe coding starter guide with interactive glossary\n- LLM journalism tool advisor (interactive decision tree)\n- Quick reference card (printable)\n- Language selection guide\n- Technical glossary (40+ terms)\n- Downloadable templates (changelog, checklist, comparison)\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n)\")",
-      "Bash(gh repo create:*)",
-      "Bash(gh api:*)",
       "Bash(git commit:*)",
-      "Bash(git push)",
-      "Bash(gh repo rename:*)",
-      "Bash(git remote set-url:*)",
-      "Bash(wc:*)",
-      "Bash(dir /s /b \"C:\\Users\\amdit\\OneDrive\\Desktop\\Crimes\\playground\\ccm\\templates\\*.md\")",
-      "Bash(findstr:*)",
+      "Bash(git push:*)",
       "Bash(git pull:*)",
+      "Bash(git rm:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git remote:*)",
+      "Bash(gh auth status:*)",
+      "Bash(gh repo:*)",
+      "Bash(gh api:*)",
+      "Bash(gh run:*)",
       "Bash(python -m http.server:*)",
-      "Bash(start http://localhost:8000/html/index.html)",
-      "Bash(netstat:*)",
+      "Bash(node:*)",
+      "Bash(npm:*)",
+      "Bash(curl:*)",
+      "Bash(wc:*)",
       "Bash(start:*)",
-      "Bash(git rm:*)"
+      "Bash(netstat:*)",
+      "Skill(*)"
     ]
+  },
+  "agents": {
+    "json-editor": {
+      "description": "Focused agent for editing LLM Advisor JSON data files",
+      "tools": ["Read", "Glob", "Grep", "Edit", "Write"],
+      "disallowedTools": ["Bash", "Task"]
+    },
+    "theme-developer": {
+      "description": "Agent for Amditis theme CSS/styling work",
+      "tools": ["Read", "Glob", "Grep", "Edit", "Write", "Bash"],
+      "allowedPaths": [
+        "resource-kit/docs/assets/*",
+        "resource-kit/docs/**/*.html",
+        "resource-kit/docs/**/*.css"
+      ]
+    },
+    "template-maintainer": {
+      "description": "Agent for LESSONS and CLAUDE-RULES template maintenance",
+      "tools": ["Read", "Glob", "Grep", "Edit", "Write"],
+      "allowedPaths": [
+        "*.md",
+        "resource-kit/docs/downloads/*.md"
+      ]
+    },
+    "content-reviewer": {
+      "description": "Read-only agent for content review and analysis",
+      "tools": ["Read", "Glob", "Grep", "WebFetch"],
+      "disallowedTools": ["Edit", "Write", "Bash"]
+    }
+  },
+  "hooks": {
+    "enabled": true
   }
 }

--- a/.claude/skills/content-auditor.md
+++ b/.claude/skills/content-auditor.md
@@ -1,0 +1,77 @@
+---
+name: content-auditor
+context: fork
+description: Runs parallel audits on LLM Advisor content for quality assurance
+---
+
+# Content Auditor Skill
+
+This skill spawns parallel sub-agents to audit different aspects of the LLM Advisor content simultaneously, leveraging Claude Code's new forked context feature.
+
+## When to Use
+
+- Before major releases or deployments
+- After bulk content updates
+- When validating contributed content
+- During periodic quality reviews
+
+## Audit Tasks (Run in Parallel)
+
+When this skill is invoked, spawn these three parallel sub-agents using the Task tool:
+
+### 1. Model Name Audit Agent
+
+Search all JSON and HTML files for outdated AI model names:
+- Check for: "Claude 4 Opus", "Claude 3", "GPT-4o", "GPT-4", "Gemini 2.", "Gemini 1."
+- Report file, line number, and suggested replacement
+- Files to check: `resource-kit/docs/llm-advisor/data/*.json`, `resource-kit/docs/**/*.html`
+
+### 2. Link Validator Agent
+
+Validate all external URLs in case studies and documentation:
+- Extract URLs from `case-studies.json` and `best-practices.json`
+- Check HTTP status codes (200 OK, redirects, 404s)
+- Report broken or redirected links
+- Suggest archive.org alternatives for dead links
+
+### 3. Content Consistency Agent
+
+Check for consistency across all data files:
+- Model names match between `model-info.json` and `decision-tree.json`
+- Tool names are consistent across all files
+- Category labels match across decision tree and comparisons
+- No orphaned references (items referenced but not defined)
+
+## Output Format
+
+Return a consolidated audit report:
+
+```markdown
+## Content Audit Report
+
+### Model Names
+- ✅ All model names current
+  OR
+- ⚠️ Found 3 outdated references:
+  - file.json:42 - "GPT-4o" → "GPT 5.1"
+
+### External Links
+- ✅ All 15 links valid
+  OR
+- ⚠️ Found 2 issues:
+  - case-studies.json: example.com/article (404)
+
+### Content Consistency
+- ✅ All references valid
+  OR
+- ⚠️ Found inconsistencies:
+  - "Claude Opus" vs "Claude 4.5 Opus" mismatch
+```
+
+## Usage
+
+```
+/content-auditor
+```
+
+Or invoke when quality assurance is needed before deployment.

--- a/.claude/skills/multi-format-export.md
+++ b/.claude/skills/multi-format-export.md
@@ -1,0 +1,107 @@
+---
+name: multi-format-export
+context: fork
+description: Export decision tree data to multiple formats simultaneously
+---
+
+# Multi-Format Export Skill
+
+This skill exports LLM Advisor decision tree data to multiple documentation formats in parallel, using Claude Code's forked context feature.
+
+## When to Use
+
+- Creating documentation for the resource kit
+- Generating printable reference materials
+- Preparing content for presentations
+- Archiving decision tree structure
+
+## Export Formats (Generated in Parallel)
+
+### 1. Mermaid Flowchart
+
+Convert `decision-tree.json` to Mermaid diagram syntax:
+
+```mermaid
+graph TD
+    start[What task?] --> research[Research]
+    start --> content[Content Creation]
+    research --> r_type{Type?}
+    r_type --> background[Background Research]
+    r_type --> sources[Finding Sources]
+```
+
+Output: `exports/decision-tree.mmd`
+
+### 2. CSV Spreadsheet
+
+Flatten decision tree to tabular format:
+
+```csv
+node_id,question,option_text,next_node,recommendation
+start,"What task?",Research,research,
+start,"What task?",Content Creation,content,
+research,"Research type?",Background,background,"Use Claude 4.5 Opus"
+```
+
+Output: `exports/decision-tree.csv`
+
+### 3. Markdown Table
+
+Create navigable documentation:
+
+```markdown
+## Decision Tree Structure
+
+### Start: What journalism task are you working on?
+
+| Option | Leads To | Notes |
+|--------|----------|-------|
+| Research & background | research | Deep analysis tasks |
+| Content creation | content | Writing and editing |
+```
+
+Output: `exports/decision-tree-docs.md`
+
+### 4. JSON Schema
+
+Generate JSON Schema for validation:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["start"],
+  "properties": {
+    "start": {
+      "type": "object",
+      "required": ["question", "options"]
+    }
+  }
+}
+```
+
+Output: `exports/decision-tree.schema.json`
+
+## Usage
+
+```
+/multi-format-export
+```
+
+Or specify formats:
+
+```
+/multi-format-export mermaid csv
+```
+
+## Output Location
+
+All exports are placed in `resource-kit/docs/exports/` directory.
+
+## Integration
+
+The Mermaid output can be embedded in GitHub README files or rendered with tools like:
+- GitHub Mermaid preview
+- Mermaid Live Editor
+- Obsidian notes
+- Notion pages

--- a/.claude/skills/template-factory.md
+++ b/.claude/skills/template-factory.md
@@ -1,0 +1,88 @@
+---
+name: template-factory
+context: fork
+description: Generate both LESSONS and CLAUDE-RULES templates in parallel for a new project
+---
+
+# Template Factory Skill
+
+This skill generates matching LESSONS and CLAUDE-RULES templates simultaneously for a new project, using Claude Code's forked context feature for parallel generation.
+
+## When to Use
+
+- Starting a new journalism project
+- Setting up Claude Code memory for a new tool
+- Creating project documentation templates
+- Onboarding a new development workflow
+
+## How It Works
+
+When the user describes their project, spawn TWO parallel sub-agents:
+
+### Agent 1: LESSONS Generator
+
+Create a project retrospective template based on:
+- Project type (software or journalism category)
+- Key milestones and phases
+- Technical stack and decisions
+- Team structure and roles
+
+Output: `LESSONS-{project-name}.md`
+
+### Agent 2: CLAUDE-RULES Generator
+
+Create a Claude Code memory file based on:
+- Project architecture and structure
+- Coding conventions and patterns
+- File organization and naming
+- Common commands and workflows
+- Things to avoid
+
+Output: `CLAUDE-RULES-{project-name}.md`
+
+## Template Categories
+
+### Software Development
+- `general` - Generic software project
+- `desktop-app` - Electron/native apps
+- `browser-extension` - Chrome/Firefox extensions
+- `web-app` - Full-stack web applications
+- `data-pipeline` - ETL and data processing
+- `mobile-app` - iOS/Android development
+
+### Journalism/Publishing
+- `digital-archive` - Historical content preservation
+- `event-website` - Conference/event sites
+- `content-pipeline` - CMS and publishing workflows
+- `editorial-tool` - Newsroom productivity tools
+- `research-project` - Investigation and analysis
+- `publication` - News sites and magazines
+
+## Usage
+
+Invoke the skill and describe your project:
+
+```
+/template-factory
+
+"I'm building a browser extension for journalists that helps verify social media claims.
+It uses React, integrates with fact-checking APIs, and will be distributed via Chrome Web Store."
+```
+
+The skill will generate both templates in parallel, customized to your specific project.
+
+## Output
+
+```
+Generated 2 files:
+
+1. LESSONS-claim-verifier-extension.md
+   - Browser extension retrospective template
+   - Sections for: API integration, store submission, user feedback
+
+2. CLAUDE-RULES-claim-verifier-extension.md
+   - Extension architecture overview
+   - React patterns and state management
+   - Manifest v3 conventions
+   - Testing workflows
+```

--- a/FEATURE-PROPOSALS.md
+++ b/FEATURE-PROPOSALS.md
@@ -1,0 +1,626 @@
+# Claude Code Feature Proposals for Amditis Resource Kit
+
+This document outlines creative ways to leverage newly released Claude Code features (v2.1.0-2.1.2) for the Amditis Resource Kit journalism tools project.
+
+---
+
+## Table of Contents
+
+1. [Hooks & Automation](#1-hooks--automation)
+2. [Forked Context Skills](#2-forked-context-skills)
+3. [MCP Server Integration](#3-mcp-server-integration)
+4. [Session Management](#4-session-management)
+5. [Background Tasks](#5-background-tasks)
+6. [Language & Internationalization](#6-language--internationalization)
+7. [Plan Mode Workflows](#7-plan-mode-workflows)
+8. [Agent-Scoped Development](#8-agent-scoped-development)
+9. [LSP Integration](#9-lsp-integration)
+10. [Tool Restrictions](#10-tool-restrictions)
+
+---
+
+## 1. Hooks & Automation
+
+### 1.1 Model Name Validator Hook (PostToolUse)
+
+**Feature Used:** `PostToolUse` hook with `once: false`
+
+Automatically validate that all AI model names in edited files follow the naming convention (Claude 4.5 Opus, Gemini 3.0 Pro, etc.)
+
+```yaml
+# .claude/hooks/model-validator.yml
+hooks:
+  - type: PostToolUse
+    tool: Edit
+    command: |
+      FILE="${CLAUDE_TOOL_INPUT_FILE_PATH}"
+      if [[ "$FILE" == *.json ]] || [[ "$FILE" == *.html ]] || [[ "$FILE" == *.md ]]; then
+        if grep -qE "Claude 4 Opus|GPT-4o|Gemini 2\." "$FILE"; then
+          echo "⚠️ OUTDATED MODEL NAME DETECTED in $FILE"
+          echo "Run: /model-name-validator skill to fix"
+          exit 1
+        fi
+      fi
+```
+
+### 1.2 Amditis Theme Validator Hook (PreToolUse)
+
+**Feature Used:** `PreToolUse` hook
+
+Prevent accidental light-theme class usage before any CSS/HTML edit:
+
+```yaml
+# .claude/hooks/theme-validator.yml
+hooks:
+  - type: PreToolUse
+    tool: Edit
+    condition: |
+      [[ "${CLAUDE_TOOL_INPUT_FILE_PATH}" == *.css ]] ||
+      [[ "${CLAUDE_TOOL_INPUT_FILE_PATH}" == *.html ]]
+    command: |
+      # Check if new_string contains forbidden theme classes
+      if echo "$CLAUDE_TOOL_INPUT_NEW_STRING" | grep -qE "bg-light-|dark:bg-dark-|bg-accent-"; then
+        echo "🚫 BLOCKED: Light theme classes detected"
+        echo "Use Amditis theme: bg-void, bg-panel, bg-surface"
+        exit 1
+      fi
+```
+
+### 1.3 JSON Schema Validation Hook
+
+**Feature Used:** `PostToolUse` hook for Write/Edit on JSON files
+
+Validate LLM Advisor data files after modification:
+
+```yaml
+# .claude/hooks/json-validator.yml
+hooks:
+  - type: PostToolUse
+    tool: [Edit, Write]
+    condition: '[[ "${CLAUDE_TOOL_INPUT_FILE_PATH}" == *llm-advisor/data/*.json ]]'
+    command: |
+      FILE="${CLAUDE_TOOL_INPUT_FILE_PATH}"
+      if ! node -e "JSON.parse(require('fs').readFileSync('$FILE'))"; then
+        echo "❌ Invalid JSON in $FILE"
+        exit 1
+      fi
+      echo "✅ JSON valid: $FILE"
+```
+
+### 1.4 Deployment Status Hook (Stop)
+
+**Feature Used:** `Stop` hook with `once: true`
+
+Remind about GitHub Pages deployment after session ends:
+
+```yaml
+# .claude/hooks/deploy-reminder.yml
+hooks:
+  - type: Stop
+    once: true
+    command: |
+      if git status --porcelain | grep -q .; then
+        echo "📦 Uncommitted changes detected!"
+        echo "Remember: Push to master for GitHub Pages deployment"
+        echo "Check status: gh run list --limit 3"
+      fi
+```
+
+### 1.5 Session Start Hook for Development Environment
+
+**Feature Used:** `SessionStart` hook
+
+Set up the development environment automatically:
+
+```yaml
+# .claude/hooks/session-start.yml
+hooks:
+  - type: SessionStart
+    command: |
+      echo "🎨 Amditis Resource Kit Development Session"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+      # Check if local server is running
+      if ! curl -s http://localhost:8000 > /dev/null 2>&1; then
+        echo "💡 Tip: Start local server with:"
+        echo "   cd resource-kit/docs && python -m http.server 8000"
+      else
+        echo "✅ Local server running at http://localhost:8000"
+      fi
+
+      # Show pending GitHub Actions
+      echo ""
+      echo "📊 Recent deployments:"
+      gh run list --limit 2 2>/dev/null || echo "   (gh CLI not configured)"
+```
+
+---
+
+## 2. Forked Context Skills
+
+### 2.1 Parallel Content Auditor
+
+**Feature Used:** `context: fork` in skill frontmatter
+
+Create a skill that spawns parallel sub-agents to audit different aspects simultaneously:
+
+```markdown
+---
+name: content-auditor
+context: fork
+description: Runs parallel audits on LLM Advisor content
+---
+
+# Content Auditor Skill
+
+When invoked, spawn three parallel sub-agents:
+
+1. **Model Name Audit** - Check all JSON for outdated model names
+2. **Link Validator** - Verify all external URLs in case-studies.json
+3. **Accessibility Check** - Audit HTML for ARIA labels and alt text
+
+Each sub-agent reports back findings independently.
+```
+
+### 2.2 Template Generator with Forked Specialization
+
+**Feature Used:** `context: fork` for specialized template generation
+
+```markdown
+---
+name: template-factory
+context: fork
+description: Generate both LESSONS and CLAUDE-RULES templates in parallel
+---
+
+# Template Factory
+
+When user describes a project, spawn two parallel agents:
+
+1. **LESSONS Generator** - Creates retrospective template
+2. **CLAUDE-RULES Generator** - Creates Claude memory file
+
+Both use shared project context but work independently.
+```
+
+### 2.3 Multi-Format Export Skill
+
+**Feature Used:** `context: fork` for parallel format conversion
+
+```markdown
+---
+name: multi-export
+context: fork
+description: Export decision tree to multiple formats simultaneously
+---
+
+# Multi-Format Export
+
+Export current decision-tree.json to:
+- Mermaid diagram (for documentation)
+- CSV (for spreadsheet users)
+- Markdown table (for README)
+
+All conversions run in parallel.
+```
+
+---
+
+## 3. MCP Server Integration
+
+### 3.1 LLM Advisor Data Management Server
+
+**Feature Used:** MCP server with `list_changed` notifications
+
+Create a custom MCP server for managing LLM Advisor JSON data:
+
+```javascript
+// mcp-servers/llm-advisor-data/index.js
+const { Server } = require('@modelcontextprotocol/sdk');
+
+const server = new Server({
+  name: 'llm-advisor-data',
+  version: '1.0.0'
+});
+
+// Tools that dynamically update based on data files
+server.tools = {
+  'add-decision-node': async ({ parent, question, options }) => {
+    // Add node to decision-tree.json
+    // Emit list_changed if new branch types added
+  },
+
+  'add-case-study': async ({ title, organization, challenge, solution }) => {
+    // Add to case-studies.json with validation
+  },
+
+  'update-model-info': async ({ model, updates }) => {
+    // Update model-info.json with version tracking
+  },
+
+  'validate-all-json': async () => {
+    // Validate all 6 JSON files against schemas
+  }
+};
+```
+
+**Settings configuration:**
+
+```json
+{
+  "mcpServers": {
+    "llm-advisor-data": {
+      "command": "node",
+      "args": ["./mcp-servers/llm-advisor-data/index.js"]
+    }
+  },
+  "permissions": {
+    "allow": ["mcp__llm-advisor-data__*"]
+  }
+}
+```
+
+### 3.2 Amditis Theme Token Server
+
+**Feature Used:** MCP server for design system tokens
+
+```javascript
+// mcp-servers/amditis-theme/index.js
+const server = new Server({
+  name: 'amditis-theme',
+  version: '1.0.0'
+});
+
+server.tools = {
+  'get-color': async ({ semantic }) => {
+    // Returns: { "primary": "#ccff00", "class": "text-acid" }
+  },
+
+  'suggest-component': async ({ type }) => {
+    // Returns Amditis-styled HTML snippet for buttons, cards, etc.
+  },
+
+  'validate-classes': async ({ classes }) => {
+    // Check if CSS classes follow Amditis conventions
+  }
+};
+```
+
+---
+
+## 4. Session Management
+
+### 4.1 Named Sessions for Feature Development
+
+**Feature Used:** `/rename` command and `--resume <name>`
+
+Create semantic session names for different development contexts:
+
+```bash
+# LLM Advisor enhancements
+claude
+/rename llm-advisor-v2
+
+# Later, resume specifically
+claude --resume llm-advisor-v2
+```
+
+**Recommended session naming conventions:**
+
+| Session Name | Purpose |
+|-------------|---------|
+| `llm-advisor-data` | JSON content updates |
+| `llm-advisor-ui` | UI/UX improvements |
+| `template-updates` | LESSONS/CLAUDE-RULES maintenance |
+| `theme-refinement` | Amditis CSS updates |
+| `skill-development` | Creating new .claude/skills |
+| `deployment-fix` | GitHub Pages issues |
+
+### 4.2 Session Statistics for Journalism Workflow
+
+**Feature Used:** `/stats` command
+
+Track Claude usage patterns across journalism tool development:
+
+```
+/stats
+
+# Output shows:
+# - Favorite model (probably Claude 4.5 Opus for complex JSON work)
+# - Usage patterns (peak hours, weekend vs weekday)
+# - Streaks (consecutive days of development)
+```
+
+---
+
+## 5. Background Tasks
+
+### 5.1 Parallel JSON Validation
+
+**Feature Used:** Background tasks with wake-up messaging
+
+Run validation on all JSON files while continuing conversation:
+
+```markdown
+# Skill: background-validator
+
+1. Start background validation: `node scripts/validate-all-json.js &`
+2. Continue working on other tasks
+3. Receive notification when validation completes
+4. Review any errors found
+```
+
+### 5.2 Local Server with Live Reload
+
+**Feature Used:** Background bash commands with Ctrl+B
+
+```bash
+# Start server in background
+cd resource-kit/docs && python -m http.server 8000 &
+
+# Continue development
+# Use Ctrl+B to background all foreground tasks
+
+# Server runs persistently during session
+```
+
+### 5.3 GitHub Actions Monitoring
+
+**Feature Used:** Background polling for deployment status
+
+```bash
+# Monitor deployment in background
+while true; do
+  STATUS=$(gh run list --limit 1 --json status -q '.[0].status')
+  if [ "$STATUS" = "completed" ]; then
+    echo "🚀 Deployment complete!"
+    break
+  fi
+  sleep 30
+done &
+```
+
+---
+
+## 6. Language & Internationalization
+
+### 6.1 Multilingual Content Development
+
+**Feature Used:** `language` setting in settings.json
+
+For developing internationalized versions of the resource kit:
+
+```json
+// .claude/settings.local.json
+{
+  "language": "spanish"
+}
+```
+
+Use for:
+- Translating decision tree content
+- Creating Spanish/French/Portuguese versions of templates
+- Adapting case studies for international newsrooms
+
+### 6.2 Language-Specific Skills
+
+Create skills for each target language:
+
+```markdown
+---
+name: spanish-translator
+language: spanish
+---
+
+# Spanish Translation Skill
+
+Translate LLM Advisor content maintaining:
+- Journalism terminology accuracy
+- Latin American vs. Castilian preferences
+- Cultural context in case studies
+```
+
+---
+
+## 7. Plan Mode Workflows
+
+### 7.1 /plan for Complex Features
+
+**Feature Used:** `/plan` command, plan mode rejection feedback
+
+Use plan mode for multi-file changes:
+
+```
+User: I want to add a "Verification Tools" category to the LLM Advisor
+
+/plan
+
+[Claude enters plan mode]
+[Explores codebase thoroughly]
+[Writes plan to plan.md]
+[User reviews and requests changes]
+[Plan is refined before implementation]
+```
+
+### 7.2 Shift+Tab for Rapid Prototyping
+
+**Feature Used:** Shift+Tab auto-accept edits in plan mode
+
+For quick iterations on template designs:
+
+1. Enter plan mode
+2. Press Shift+Tab to enable auto-accept
+3. Rapidly iterate on template structure
+4. Review all changes at once
+
+---
+
+## 8. Agent-Scoped Development
+
+### 8.1 Specialized Development Agents
+
+**Feature Used:** `--agent` flag, `agent_type` in hooks
+
+Create focused development sessions:
+
+```bash
+# JSON content editing only
+claude --agent json-editor
+
+# Theme development only
+claude --agent theme-developer
+
+# Template maintenance
+claude --agent template-maintainer
+```
+
+### 8.2 Agent Hooks for Specialized Validation
+
+**Feature Used:** Agent-scoped hooks
+
+```yaml
+# .claude/hooks/agent-json-editor.yml
+hooks:
+  - type: PostToolUse
+    agent: json-editor
+    tool: Edit
+    command: |
+      # Extra strict JSON validation for json-editor agent
+      node scripts/deep-validate-json.js
+```
+
+---
+
+## 9. LSP Integration
+
+### 9.1 JavaScript Navigation for app.js
+
+**Feature Used:** LSP tool for go-to-definition, find references
+
+Use LSP for navigating the 573-line LLM Advisor app.js:
+
+```
+# Find all references to showModal function
+LSP: find-references showModal
+
+# Go to definition of handleDecisionClick
+LSP: go-to-definition handleDecisionClick
+
+# Get hover documentation for event handlers
+LSP: hover addEventListener
+```
+
+### 9.2 CSS Variable Tracking
+
+Use LSP for tracking Amditis theme variables:
+
+```
+# Find all uses of --acid color
+LSP: find-references --acid
+
+# Track theme variable cascade
+LSP: go-to-definition bg-void
+```
+
+---
+
+## 10. Tool Restrictions
+
+### 10.1 Content-Only Sessions
+
+**Feature Used:** `--tools` flag, `--disallowedTools`
+
+For journalists reviewing content without code changes:
+
+```bash
+# Read-only exploration
+claude --tools Read,Glob,Grep
+
+# No file modifications allowed
+claude --disallowedTools Edit,Write,Bash
+```
+
+### 10.2 Disable Specific Agents
+
+**Feature Used:** `Task(AgentName)` syntax for disabling
+
+```json
+{
+  "disallowedTools": [
+    "Task(general-purpose)",
+    "Bash"
+  ]
+}
+```
+
+Use for controlled template editing sessions.
+
+---
+
+## Implementation Priority
+
+### Phase 1: Immediate Value (This Week)
+1. Session start hook for development environment
+2. Model name validator hook
+3. Named sessions for feature branches
+4. Background server workflow
+
+### Phase 2: Enhanced Workflow (Next 2 Weeks)
+5. JSON schema validation hooks
+6. Forked context skills for parallel audits
+7. Plan mode for complex features
+8. Agent-scoped development
+
+### Phase 3: Advanced Integration (Month 2)
+9. MCP server for LLM Advisor data
+10. LSP integration for app.js navigation
+11. Multi-language skill variants
+12. Automated deployment hooks
+
+---
+
+## Quick Reference: New Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| Alt+T | Toggle thinking mode |
+| Alt+P | Switch models mid-prompt |
+| Shift+Tab | Auto-accept edits (plan mode) |
+| Ctrl+B | Background all foreground tasks |
+| ; / , | Repeat f/F/t/T vim motions |
+
+---
+
+## Files to Create
+
+Based on these proposals, the following files should be created:
+
+```
+.claude/
+├── hooks/
+│   ├── model-validator.yml
+│   ├── theme-validator.yml
+│   ├── json-validator.yml
+│   ├── deploy-reminder.yml
+│   └── session-start.yml
+├── skills/
+│   ├── content-auditor.md (context: fork)
+│   ├── template-factory.md (context: fork)
+│   ├── multi-export.md (context: fork)
+│   └── spanish-translator.md
+└── settings.local.json (updated with MCP, permissions)
+
+mcp-servers/
+├── llm-advisor-data/
+│   └── index.js
+└── amditis-theme/
+    └── index.js
+
+scripts/
+├── validate-all-json.js
+└── deep-validate-json.js
+```
+
+---
+
+*Generated for the Amditis Resource Kit project based on Claude Code v2.1.0-2.1.2 changelog analysis.*

--- a/mcp-servers/llm-advisor-data/index.js
+++ b/mcp-servers/llm-advisor-data/index.js
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+/**
+ * MCP Server: LLM Advisor Data Management
+ *
+ * Provides tools for managing LLM Advisor JSON data files with:
+ * - Schema validation
+ * - CRUD operations for decision tree nodes
+ * - Case study management
+ * - Model info updates
+ * - Dynamic tool updates via list_changed notifications
+ *
+ * New Claude Code v2.1 Features Used:
+ * - MCP list_changed notifications for dynamic tool updates
+ * - Wildcard permissions (mcp__llm-advisor-data__*)
+ */
+
+const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const fs = require("fs").promises;
+const path = require("path");
+
+// Data file paths
+const DATA_DIR = path.join(__dirname, "../../resource-kit/docs/llm-advisor/data");
+const FILES = {
+  decisionTree: path.join(DATA_DIR, "decision-tree.json"),
+  caseStudies: path.join(DATA_DIR, "case-studies.json"),
+  modelInfo: path.join(DATA_DIR, "model-info.json"),
+  toolComparison: path.join(DATA_DIR, "tool-comparison.json"),
+  bestPractices: path.join(DATA_DIR, "best-practices.json"),
+  changelog: path.join(DATA_DIR, "changelog.json"),
+};
+
+// Model name validation
+const VALID_MODELS = [
+  "Claude 4.5 Opus",
+  "Claude 4.5 Sonnet",
+  "Gemini 3.0 Pro",
+  "Gemini 3.0 Flash",
+  "GPT 5.1",
+  "Codex (GPT 5.1)",
+];
+
+// Create server instance
+const server = new Server(
+  {
+    name: "llm-advisor-data",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Helper: Read JSON file
+async function readJsonFile(filePath) {
+  const content = await fs.readFile(filePath, "utf8");
+  return JSON.parse(content);
+}
+
+// Helper: Write JSON file with pretty formatting
+async function writeJsonFile(filePath, data) {
+  const content = JSON.stringify(data, null, 2);
+  await fs.writeFile(filePath, content, "utf8");
+}
+
+// Helper: Validate model names
+function validateModelName(name) {
+  if (!VALID_MODELS.includes(name)) {
+    throw new Error(
+      `Invalid model name: "${name}". Valid names: ${VALID_MODELS.join(", ")}`
+    );
+  }
+  return true;
+}
+
+// Define tools
+server.setRequestHandler("tools/list", async () => {
+  return {
+    tools: [
+      {
+        name: "list_decision_nodes",
+        description: "List all nodes in the decision tree",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "get_decision_node",
+        description: "Get a specific decision tree node by ID",
+        inputSchema: {
+          type: "object",
+          properties: {
+            nodeId: {
+              type: "string",
+              description: "The node ID (e.g., 'start', 'research', 'content')",
+            },
+          },
+          required: ["nodeId"],
+        },
+      },
+      {
+        name: "add_decision_node",
+        description: "Add a new node to the decision tree",
+        inputSchema: {
+          type: "object",
+          properties: {
+            nodeId: {
+              type: "string",
+              description: "Unique ID for the new node",
+            },
+            question: {
+              type: "string",
+              description: "The question to display at this node",
+            },
+            options: {
+              type: "array",
+              description: "Array of option objects with text and next fields",
+              items: {
+                type: "object",
+                properties: {
+                  text: { type: "string" },
+                  next: { type: "string" },
+                },
+              },
+            },
+          },
+          required: ["nodeId", "question", "options"],
+        },
+      },
+      {
+        name: "add_case_study",
+        description: "Add a new case study to the collection",
+        inputSchema: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              description: "Case study title",
+            },
+            organization: {
+              type: "string",
+              description: "News organization name",
+            },
+            challenge: {
+              type: "string",
+              description: "The challenge they faced",
+            },
+            solution: {
+              type: "string",
+              description: "How they solved it with AI",
+            },
+            tools: {
+              type: "array",
+              description: "AI tools used",
+              items: { type: "string" },
+            },
+            outcome: {
+              type: "string",
+              description: "Results achieved",
+            },
+          },
+          required: ["title", "organization", "challenge", "solution"],
+        },
+      },
+      {
+        name: "update_model_info",
+        description: "Update information for an AI model",
+        inputSchema: {
+          type: "object",
+          properties: {
+            modelName: {
+              type: "string",
+              description: `Model name (one of: ${VALID_MODELS.join(", ")})`,
+            },
+            updates: {
+              type: "object",
+              description: "Fields to update (description, strengths, weaknesses, etc.)",
+            },
+          },
+          required: ["modelName", "updates"],
+        },
+      },
+      {
+        name: "validate_all_json",
+        description: "Validate all JSON data files for syntax and consistency",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "check_model_names",
+        description: "Check all files for outdated model names",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "add_changelog_entry",
+        description: "Add a new entry to the changelog",
+        inputSchema: {
+          type: "object",
+          properties: {
+            version: {
+              type: "string",
+              description: "Version number (e.g., '2.1.0')",
+            },
+            date: {
+              type: "string",
+              description: "Release date (YYYY-MM-DD)",
+            },
+            changes: {
+              type: "array",
+              description: "Array of change descriptions",
+              items: { type: "string" },
+            },
+          },
+          required: ["version", "changes"],
+        },
+      },
+    ],
+  };
+});
+
+// Handle tool calls
+server.setRequestHandler("tools/call", async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case "list_decision_nodes": {
+        const tree = await readJsonFile(FILES.decisionTree);
+        const nodes = Object.keys(tree).map((id) => ({
+          id,
+          question: tree[id].question,
+          optionCount: tree[id].options?.length || 0,
+        }));
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(nodes, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "get_decision_node": {
+        const tree = await readJsonFile(FILES.decisionTree);
+        const node = tree[args.nodeId];
+        if (!node) {
+          throw new Error(`Node not found: ${args.nodeId}`);
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ id: args.nodeId, ...node }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "add_decision_node": {
+        const tree = await readJsonFile(FILES.decisionTree);
+        if (tree[args.nodeId]) {
+          throw new Error(`Node already exists: ${args.nodeId}`);
+        }
+        tree[args.nodeId] = {
+          question: args.question,
+          options: args.options,
+        };
+        await writeJsonFile(FILES.decisionTree, tree);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Successfully added node: ${args.nodeId}`,
+            },
+          ],
+        };
+      }
+
+      case "add_case_study": {
+        const studies = await readJsonFile(FILES.caseStudies);
+        const newStudy = {
+          id: `case-${Date.now()}`,
+          title: args.title,
+          organization: args.organization,
+          challenge: args.challenge,
+          solution: args.solution,
+          tools: args.tools || [],
+          outcome: args.outcome || "",
+          dateAdded: new Date().toISOString().split("T")[0],
+        };
+        studies.push(newStudy);
+        await writeJsonFile(FILES.caseStudies, studies);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Added case study: "${args.title}" (ID: ${newStudy.id})`,
+            },
+          ],
+        };
+      }
+
+      case "update_model_info": {
+        validateModelName(args.modelName);
+        const models = await readJsonFile(FILES.modelInfo);
+        if (!models[args.modelName]) {
+          models[args.modelName] = {};
+        }
+        Object.assign(models[args.modelName], args.updates);
+        await writeJsonFile(FILES.modelInfo, models);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Updated model info for: ${args.modelName}`,
+            },
+          ],
+        };
+      }
+
+      case "validate_all_json": {
+        const results = [];
+        for (const [name, filePath] of Object.entries(FILES)) {
+          try {
+            await readJsonFile(filePath);
+            results.push(`✅ ${name}: valid`);
+          } catch (e) {
+            results.push(`❌ ${name}: ${e.message}`);
+          }
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: results.join("\n"),
+            },
+          ],
+        };
+      }
+
+      case "check_model_names": {
+        const outdatedPatterns = [
+          /Claude 4 Opus/g,
+          /Claude 3/g,
+          /GPT-4o/g,
+          /GPT-4/g,
+          /Gemini 2\./g,
+          /Gemini 1\./g,
+        ];
+        const issues = [];
+
+        for (const [name, filePath] of Object.entries(FILES)) {
+          try {
+            const content = await fs.readFile(filePath, "utf8");
+            for (const pattern of outdatedPatterns) {
+              const matches = content.match(pattern);
+              if (matches) {
+                issues.push(`${name}: Found "${matches[0]}"`);
+              }
+            }
+          } catch (e) {
+            // Skip if file doesn't exist
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                issues.length > 0
+                  ? `Found outdated model names:\n${issues.join("\n")}`
+                  : "✅ All model names are current",
+            },
+          ],
+        };
+      }
+
+      case "add_changelog_entry": {
+        const changelog = await readJsonFile(FILES.changelog);
+        const entry = {
+          version: args.version,
+          date: args.date || new Date().toISOString().split("T")[0],
+          changes: args.changes,
+        };
+        changelog.unshift(entry);
+        await writeJsonFile(FILES.changelog, changelog);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Added changelog entry for version ${args.version}`,
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error: ${error.message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("LLM Advisor Data MCP Server running");
+}
+
+main().catch(console.error);

--- a/mcp-servers/llm-advisor-data/package.json
+++ b/mcp-servers/llm-advisor-data/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "llm-advisor-data-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for managing LLM Advisor JSON data files",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "keywords": ["mcp", "claude-code", "llm-advisor"],
+  "author": "Amditis Resource Kit",
+  "license": "MIT"
+}

--- a/scripts/background-server.sh
+++ b/scripts/background-server.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Background Development Server
+#
+# Claude Code v2.1 Feature: Background bash commands with Ctrl+B
+#
+# Usage:
+#   ./scripts/background-server.sh start    # Start server in background
+#   ./scripts/background-server.sh stop     # Stop server
+#   ./scripts/background-server.sh status   # Check if running
+#
+
+PORT=${PORT:-8000}
+DOCS_DIR="$(dirname "$0")/../resource-kit/docs"
+PID_FILE="/tmp/amditis-dev-server.pid"
+
+start_server() {
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        echo "Server already running on port $PORT (PID: $(cat "$PID_FILE"))"
+        return 1
+    fi
+
+    cd "$DOCS_DIR" || exit 1
+    python -m http.server "$PORT" &
+    echo $! > "$PID_FILE"
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🚀 Development server started"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "   URL: http://localhost:$PORT"
+    echo "   PID: $(cat "$PID_FILE")"
+    echo ""
+    echo "Pages:"
+    echo "   • Main:        http://localhost:$PORT"
+    echo "   • LLM Advisor: http://localhost:$PORT/llm-advisor"
+    echo "   • Glossary:    http://localhost:$PORT/glossary.html"
+    echo ""
+    echo "Stop with: ./scripts/background-server.sh stop"
+    echo ""
+}
+
+stop_server() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if kill -0 "$PID" 2>/dev/null; then
+            kill "$PID"
+            rm "$PID_FILE"
+            echo "✅ Server stopped (PID: $PID)"
+        else
+            rm "$PID_FILE"
+            echo "Server was not running"
+        fi
+    else
+        echo "No server PID file found"
+    fi
+}
+
+check_status() {
+    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        echo "✅ Server running on port $PORT (PID: $(cat "$PID_FILE"))"
+        echo "   http://localhost:$PORT"
+    else
+        echo "❌ Server not running"
+        [ -f "$PID_FILE" ] && rm "$PID_FILE"
+    fi
+}
+
+case "${1:-start}" in
+    start)
+        start_server
+        ;;
+    stop)
+        stop_server
+        ;;
+    status)
+        check_status
+        ;;
+    restart)
+        stop_server
+        sleep 1
+        start_server
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart}"
+        exit 1
+        ;;
+esac

--- a/scripts/validate-all-json.js
+++ b/scripts/validate-all-json.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Validate All JSON - Background Task Script
+ *
+ * Validates all LLM Advisor JSON data files for:
+ * - Syntax correctness
+ * - Schema compliance
+ * - Cross-reference integrity
+ * - Model name currency
+ *
+ * Claude Code v2.1 Feature: Run as background task
+ * Usage: node scripts/validate-all-json.js &
+ */
+
+const fs = require("fs").promises;
+const path = require("path");
+
+const DATA_DIR = path.join(
+  __dirname,
+  "../resource-kit/docs/llm-advisor/data"
+);
+
+// Valid model names (current as of Jan 2026)
+const VALID_MODELS = [
+  "Claude 4.5 Opus",
+  "Claude 4.5 Sonnet",
+  "Gemini 3.0 Pro",
+  "Gemini 3.0 Flash",
+  "GPT 5.1",
+  "Codex (GPT 5.1)",
+];
+
+// Outdated model name patterns
+const OUTDATED_PATTERNS = [
+  { pattern: /Claude 4 Opus/gi, replacement: "Claude 4.5 Opus" },
+  { pattern: /Claude 3\.?5?/gi, replacement: "Claude 4.5" },
+  { pattern: /GPT-4o/gi, replacement: "GPT 5.1" },
+  { pattern: /GPT-4/gi, replacement: "GPT 5.1" },
+  { pattern: /Gemini 2\.\d/gi, replacement: "Gemini 3.0" },
+  { pattern: /Gemini 1\.\d/gi, replacement: "Gemini 3.0" },
+];
+
+// File schemas
+const SCHEMAS = {
+  "decision-tree.json": {
+    required: ["start"],
+    nodeRequired: ["question", "options"],
+  },
+  "case-studies.json": {
+    isArray: true,
+    itemRequired: ["title", "organization", "challenge", "solution"],
+  },
+  "model-info.json": {
+    isObject: true,
+  },
+  "tool-comparison.json": {
+    isArray: true,
+  },
+  "best-practices.json": {
+    isArray: true,
+  },
+  "changelog.json": {
+    isArray: true,
+    itemRequired: ["version", "changes"],
+  },
+};
+
+async function validateFile(filename, schema) {
+  const filePath = path.join(DATA_DIR, filename);
+  const results = {
+    file: filename,
+    valid: true,
+    errors: [],
+    warnings: [],
+  };
+
+  try {
+    // Check file exists
+    const content = await fs.readFile(filePath, "utf8");
+
+    // Parse JSON
+    let data;
+    try {
+      data = JSON.parse(content);
+    } catch (e) {
+      results.valid = false;
+      results.errors.push(`JSON syntax error: ${e.message}`);
+      return results;
+    }
+
+    // Check schema requirements
+    if (schema.required) {
+      for (const key of schema.required) {
+        if (!data[key]) {
+          results.valid = false;
+          results.errors.push(`Missing required key: ${key}`);
+        }
+      }
+    }
+
+    if (schema.isArray && !Array.isArray(data)) {
+      results.valid = false;
+      results.errors.push(`Expected array, got ${typeof data}`);
+    }
+
+    if (schema.isObject && typeof data !== "object") {
+      results.valid = false;
+      results.errors.push(`Expected object, got ${typeof data}`);
+    }
+
+    if (schema.itemRequired && Array.isArray(data)) {
+      data.forEach((item, index) => {
+        for (const key of schema.itemRequired) {
+          if (!item[key]) {
+            results.warnings.push(`Item ${index}: missing ${key}`);
+          }
+        }
+      });
+    }
+
+    // Check for outdated model names
+    for (const { pattern, replacement } of OUTDATED_PATTERNS) {
+      const matches = content.match(pattern);
+      if (matches) {
+        results.warnings.push(
+          `Outdated model name: "${matches[0]}" → "${replacement}"`
+        );
+      }
+    }
+
+    // Decision tree specific validation
+    if (filename === "decision-tree.json" && schema.nodeRequired) {
+      for (const [nodeId, node] of Object.entries(data)) {
+        for (const key of schema.nodeRequired) {
+          if (!node[key]) {
+            results.warnings.push(`Node ${nodeId}: missing ${key}`);
+          }
+        }
+        // Check option references
+        if (node.options) {
+          for (const option of node.options) {
+            if (option.next && !data[option.next] && !option.recommendation) {
+              results.warnings.push(
+                `Node ${nodeId}: option "${option.text}" references non-existent node "${option.next}"`
+              );
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    if (e.code === "ENOENT") {
+      results.valid = false;
+      results.errors.push("File not found");
+    } else {
+      results.valid = false;
+      results.errors.push(`Read error: ${e.message}`);
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("  JSON VALIDATION REPORT");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("");
+
+  let allValid = true;
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  for (const [filename, schema] of Object.entries(SCHEMAS)) {
+    const results = await validateFile(filename, schema);
+
+    const icon = results.valid
+      ? results.warnings.length > 0
+        ? "⚠️"
+        : "✅"
+      : "❌";
+    console.log(`${icon} ${filename}`);
+
+    if (results.errors.length > 0) {
+      allValid = false;
+      totalErrors += results.errors.length;
+      results.errors.forEach((e) => console.log(`   ❌ ${e}`));
+    }
+
+    if (results.warnings.length > 0) {
+      totalWarnings += results.warnings.length;
+      results.warnings.forEach((w) => console.log(`   ⚠️  ${w}`));
+    }
+  }
+
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log(
+    `Summary: ${totalErrors} errors, ${totalWarnings} warnings`
+  );
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+  process.exit(allValid ? 0 : 1);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
New capabilities leveraging latest Claude Code features:

Hooks (.claude/hooks/):
- session-start: Development environment setup with once: true
- model-name-validator: PostToolUse hook for model name validation
- theme-validator: PreToolUse hook blocking light theme classes
- json-validator: PostToolUse validation for LLM Advisor JSON

Forked Context Skills (.claude/skills/):
- content-auditor: Parallel sub-agents for quality audits
- template-factory: Generate LESSONS + CLAUDE-RULES simultaneously
- multi-format-export: Export decision tree to multiple formats

Agent Configurations (settings.local.json):
- json-editor: Focused agent for JSON data files
- theme-developer: Amditis CSS/styling work
- template-maintainer: Markdown template updates
- content-reviewer: Read-only review agent

MCP Server (mcp-servers/llm-advisor-data/):
- Full CRUD for decision tree nodes
- Case study management
- Model info updates with validation
- Supports list_changed notifications

Background Tasks (scripts/):
- validate-all-json.js: Background JSON validation
- background-server.sh: Dev server management

Documentation:
- FEATURE-PROPOSALS.md: Complete implementation guide

---

This pull request introduces a comprehensive set of improvements focused on automation, validation, and parallelization for the Amditis Resource Kit project. The main changes include new hooks for validating JSON data, model names, and theme usage; enhancements to session startup experience; new specialized skills for auditing content, exporting data, and generating templates in parallel; and updates to permissions and agent configurations to support these features. Additionally, a background server management script and a new MCP server package have been added.

**Automation & Validation Hooks**

* Added `.claude/hooks/json-validator.md` to automatically validate JSON syntax and schema for LLM Advisor data files after edits, blocking invalid changes.
* Introduced `.claude/hooks/model-name-validator.md` to flag outdated AI model names in JSON, HTML, and Markdown files, guiding users to use current names.
* Implemented `.claude/hooks/theme-validator.md` to prevent use of light theme classes in CSS/HTML, enforcing Amditis dark theme standards.
* Added `.claude/hooks/session-start.md` to display a dev session banner, check local server status, show last deployment, and provide quick command reminders at session start.

**Parallelized Skills for Quality and Export**

* Added `content-auditor` skill to run parallel audits on LLM Advisor content (model names, links, consistency) and produce a consolidated report.
* Added `multi-format-export` skill to export decision tree data simultaneously to Mermaid, CSV, Markdown, and JSON Schema formats.
* Added `template-factory` skill to generate LESSONS and CLAUDE-RULES templates in parallel for new projects, supporting both software and journalism categories.

**Permissions & Agent Configuration**

* Updated `.claude/settings.local.json` to streamline and expand Bash command permissions, add new agents for JSON editing, theme development, template maintenance, and content review, and enable hooks globally.

**Developer Experience & Infrastructure**

* Added `scripts/background-server.sh` for starting, stopping, and checking the status of the local development server in the background, improving workflow efficiency.
* Introduced `mcp-servers/llm-advisor-data/package.json` for a new MCP server package to manage LLM Advisor JSON data files, supporting future protocol-based integrations.