### PR TITLE
Reword taglines with attribution and guidelines

### DIFF
--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -1464,6 +1464,7 @@ node --version  <span class="text-gray-500"># Should show v20.x.x</span></code><
             <div class="max-w-6xl mx-auto px-6 text-center text-xs font-mono text-gray-600">
                 <p>SYSTEM STATUS: ONLINE // <a href="../index.html" class="hover:text-acid transition-colors">RETURN_ROOT</a> // <a href="../vibe-coding/index.html" class="hover:text-acid transition-colors">VIBE_GUIDE</a></p>
                 <p class="mt-2">AMDITIS_KIT v2.6 // Part of the CCM Resource Collection</p>
+                <p class="mt-2 text-gray-700">Status line setup based on <a href="https://www.aihero.dev/creating-the-perfect-claude-code-status-line" class="text-gray-600 hover:text-acid transition-colors" target="_blank" rel="noopener">Matt Pocock's guide</a></p>
             </div>
         </footer>
 

--- a/resource-kit/docs/vibe-coding/index.html
+++ b/resource-kit/docs/vibe-coding/index.html
@@ -104,8 +104,8 @@
 
                 <!-- Tagline -->
                 <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8 leading-relaxed">
-                    You don't need to be a "real dev." <br class="hidden sm:inline">
-                    <span class="text-ice">You just need to know enough to ship.</span>
+                    No CS degree required. <br class="hidden sm:inline">
+                    <span class="text-ice">Build working software with AI as your co-pilot.</span>
                 </p>
 
                 <!-- Terminal-style intro -->
@@ -301,11 +301,11 @@
                     </div>
                     <div>
                         <p class="text-gray-400 font-mono leading-relaxed mb-4">
-                            <span class="text-white">Vibe coding isn't about ignoring fundamentals</span> - it's about learning them <em>just in time</em> instead of <em>just in case</em>.
-                            You'll pick up concepts as you need them, with AI as your pair programmer.
+                            <span class="text-white">Vibe coding means learning by building</span> - you pick up programming concepts when your project needs them, not years before.
+                            AI handles the syntax; you handle the thinking.
                         </p>
                         <p class="text-sm text-gray-600 font-mono">
-                            // The goal: ship real projects, learn real skills, skip the gatekeeping.
+                            // Build things. Break things. Fix them. Repeat.
                         </p>
                     </div>
                 </div>
@@ -319,7 +319,7 @@
                 <div class="flex flex-col md:flex-row justify-between items-center gap-4">
                     <div class="text-center md:text-left">
                         <p class="text-gray-500 font-mono text-sm">
-                            <span class="text-acid">//</span> Happy vibe coding. <span class="text-ice">Ship something today.</span>
+                            <span class="text-acid">//</span> Start building. <span class="text-ice">The rest comes with practice.</span>
                         </p>
                     </div>
                     <div class="flex items-center gap-6 text-xs font-mono">
@@ -336,6 +336,9 @@
                 <div class="mt-6 pt-6 border-t border-white/5 text-center">
                     <p class="text-xs text-gray-600 font-mono">
                         AMDITIS_KIT v2.6 // Part of the <a href="../index.html" class="text-gray-500 hover:text-acid transition-colors hover-line">CCM Resource Collection</a>
+                    </p>
+                    <p class="text-xs text-gray-700 font-mono mt-2">
+                        Inspired by <a href="https://www.aihero.dev/creating-the-perfect-claude-code-status-line" class="text-gray-600 hover:text-acid transition-colors hover-line" target="_blank" rel="noopener">Matt Pocock's Claude Code status line guide</a>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
- Rewrote vibe-coding taglines to be original (avoid duplication)
- Added attribution link to Matt Pocock's Claude Code status line guide
- Added attribution to terminal-setup page for status line setup content