### PR TITLE
Fix overflow issues on buttons and warning boxes

### DIFF
--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -294,7 +294,7 @@
                     </div>
                 </div>
 
-                <div class="mt-6 flex gap-4 relative z-10">
+                <div class="mt-6 flex flex-wrap gap-4 relative z-10">
                     <a href="downloads/CLAUDE-CODE-QUICKREF.md" download class="px-6 py-2 bg-ice text-black font-bold text-xs clip-notch hover:bg-white transition-colors flex items-center gap-2">
                         <i data-lucide="download" class="w-4 h-4"></i> DOWNLOAD_QUICKREF
                     </a>

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -424,10 +424,10 @@
                                                 <pre class="p-4 text-sm overflow-x-auto"><code class="text-gray-300">/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"</code></pre>
                                             </div>
 
-                                            <div class="bg-signal/10 border border-signal/30 p-4 rounded">
-                                                <div class="flex items-start gap-3">
+                                            <div class="bg-signal/10 border border-signal/30 p-4 rounded overflow-hidden">
+                                                <div class="flex items-start gap-3 min-w-0">
                                                     <i data-lucide="alert-triangle" class="w-5 h-5 text-signal shrink-0 mt-0.5"></i>
-                                                    <div>
+                                                    <div class="min-w-0 flex-1">
                                                         <div class="text-signal text-sm font-bold mb-1">Apple Silicon Macs (M1/M2/M3/M4)</div>
                                                         <p class="text-gray-400 text-xs mb-2">After installation, you MUST add Homebrew to your PATH:</p>
                                                         <div class="code-block rounded overflow-hidden mt-2">


### PR DESCRIPTION
- Add flex-wrap to button container on main page to prevent EXPLORE_TOOLS button cutoff
- Add overflow-hidden and min-w-0 to Apple Silicon warning box to contain content properly