### PR TITLE
Integrate Claude code patterns into website

### DIFF
--- a/resource-kit/docs/code-patterns/index.html
+++ b/resource-kit/docs/code-patterns/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VIBE_CODING // AMDITIS KIT</title>
-    <meta name="description" content="The vibe coder's guide - Learn to ship code with AI without being a 'real' developer.">
+    <title>CODE_PATTERNS // AMDITIS KIT</title>
+    <meta name="description" content="Advanced Claude Code patterns for building reliable AI-assisted workflows. Seven core lessons from 2000+ hours of LLM development.">
     <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 
     <!-- CSS & Config -->
@@ -71,7 +71,7 @@
                 <a href="../index.html" class="flex items-center gap-3 group">
                     <div class="w-8 h-8 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch group-hover:bg-white transition-colors">A</div>
                     <div>
-                        <div class="font-display font-bold text-sm tracking-wider text-chrome group-hover:text-acid transition-colors">VIBE_CODING</div>
+                        <div class="font-display font-bold text-sm tracking-wider text-chrome group-hover:text-acid transition-colors">CODE_PATTERNS</div>
                         <div class="text-xs text-gray-500 tracking-[0.2em]">AMDITIS_KIT</div>
                     </div>
                 </a>
@@ -88,24 +88,24 @@
         <section class="py-16 md:py-24 px-6 text-center border-b border-white/10 relative overflow-hidden">
             <!-- Gradient glow -->
             <div class="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-acid/5 blur-[100px] rounded-full pointer-events-none"></div>
-            <div class="absolute bottom-0 right-1/4 w-[400px] h-[200px] bg-ice/5 blur-[80px] rounded-full pointer-events-none"></div>
+            <div class="absolute bottom-0 right-1/4 w-[400px] h-[200px] bg-signal/5 blur-[80px] rounded-full pointer-events-none"></div>
 
             <div class="max-w-4xl mx-auto relative z-10">
                 <!-- Status badge -->
                 <div class="inline-flex items-center gap-2 px-4 py-2 mb-8 border border-acid/30 text-acid text-xs font-mono tracking-widest bg-acidDim">
                     <span class="w-2 h-2 bg-acid rounded-full pulse-status"></span>
-                    MODE: VIBE_ACTIVE
+                    MODE: ADVANCED
                 </div>
 
                 <!-- Glitch title -->
-                <h1 class="font-display text-4xl sm:text-5xl md:text-7xl font-bold mb-6 text-white tracking-tight glitch-text" data-text="VIBE CODER'S GUIDE">
-                    VIBE CODER'S GUIDE
+                <h1 class="font-display text-4xl sm:text-5xl md:text-7xl font-bold mb-6 text-white tracking-tight glitch-text" data-text="CLAUDE CODE PATTERNS">
+                    CLAUDE CODE PATTERNS
                 </h1>
 
                 <!-- Tagline -->
                 <p class="text-gray-400 text-lg md:text-xl font-mono max-w-2xl mx-auto mb-8 leading-relaxed">
-                    No CS degree required. <br class="hidden sm:inline">
-                    <span class="text-ice">Build working software with AI as your co-pilot.</span>
+                    Seven battle-tested patterns from 2000+ hours of LLM development. <br class="hidden sm:inline">
+                    <span class="text-signal">Master the feedback loops that make AI reliable.</span>
                 </p>
 
                 <!-- Terminal-style intro -->
@@ -114,14 +114,14 @@
                         <span class="w-3 h-3 rounded-full bg-signal"></span>
                         <span class="w-3 h-3 rounded-full bg-acid"></span>
                         <span class="w-3 h-3 rounded-full bg-ice"></span>
-                        <span class="text-xs text-gray-600 ml-2">vibe_init.sh</span>
+                        <span class="text-xs text-gray-600 ml-2">patterns_init.sh</span>
                     </div>
                     <code class="text-gray-500">
-                        <span class="text-acid">$</span> ./start_vibing --mode=<span class="text-ice">build</span><br>
-                        <span class="text-gray-600"># Loading AI assistants...</span><br>
-                        <span class="text-gray-600"># Syntax memorization: DISABLED</span><br>
-                        <span class="text-gray-600"># Ship-first mindset: ENABLED</span><br>
-                        <span class="text-acid">Ready.</span> <span class="text-white">Pick your path below.</span>
+                        <span class="text-acid">$</span> ./load_patterns --source=<span class="text-signal">production</span><br>
+                        <span class="text-gray-600"># Core philosophy: YOU own the failures</span><br>
+                        <span class="text-gray-600"># Either bad prompts or bad context</span><br>
+                        <span class="text-gray-600"># Fix the system, not the symptoms</span><br>
+                        <span class="text-acid">Ready.</span> <span class="text-white">Select your module below.</span>
                     </code>
                 </div>
             </div>
@@ -130,79 +130,100 @@
         <!-- Main Content -->
         <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-12 md:py-16">
 
+            <!-- Core Philosophy -->
+            <section class="mb-16 border border-signal/30 bg-surface/50 p-6 md:p-8 relative">
+                <div class="absolute -top-3 left-6 bg-void px-3 text-xs text-signal font-mono">
+                    CORE_PRINCIPLE
+                </div>
+                <div class="flex items-start gap-4">
+                    <div class="text-signal mt-1 hidden sm:block">
+                        <i data-lucide="alert-triangle" class="w-6 h-6"></i>
+                    </div>
+                    <div>
+                        <p class="text-gray-400 font-mono leading-relaxed mb-4">
+                            <span class="text-white">"Any issue in LLM-generated code is solely due to YOU, the user."</span>
+                            Problems trace back to two root causes: inadequate prompt engineering or insufficient context management.
+                        </p>
+                        <p class="text-sm text-gray-600 font-mono">
+                            // The patterns below fix both. No more blaming the model.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
             <!-- Primary Paths Section -->
             <section class="mb-16">
                 <div class="border-b border-white/10 pb-4 mb-8">
                     <div class="flex items-end justify-between">
-                        <h2 class="font-display text-xl md:text-2xl text-white">// CHOOSE_YOUR_PATH</h2>
+                        <h2 class="font-display text-xl md:text-2xl text-white">// CORE_MODULES</h2>
                         <span class="text-xs text-gray-600 font-mono hidden sm:inline">START_HERE</span>
                     </div>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 
-                    <!-- THE BASICS Card -->
-                    <a href="essentials.html" class="group block border border-white/10 bg-panel hover:border-acid transition-all duration-300 relative overflow-hidden card-glow-acid">
+                    <!-- LESSONS Card -->
+                    <a href="lessons.html" class="group block border border-white/10 bg-panel hover:border-acid transition-all duration-300 relative overflow-hidden card-glow-acid">
                         <!-- Corner accent -->
                         <div class="absolute top-0 left-0 w-16 h-16 border-l-2 border-t-2 border-acid/50 group-hover:border-acid transition-colors"></div>
                         <div class="absolute bottom-0 right-0 w-16 h-16 border-r-2 border-b-2 border-acid/50 group-hover:border-acid transition-colors"></div>
 
                         <!-- Icon -->
                         <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-acid">
-                            <i data-lucide="shield-check" class="w-10 h-10"></i>
+                            <i data-lucide="graduation-cap" class="w-10 h-10"></i>
                         </div>
 
                         <div class="p-8 relative">
                             <div class="text-xs text-acid font-mono mb-3 tracking-widest">:: MODULE_01</div>
                             <h3 class="font-display text-2xl md:text-3xl text-white font-bold mb-4 group-hover:text-acid transition-colors">
-                                THE BASICS
+                                SEVEN LESSONS
                             </h3>
                             <p class="text-gray-500 font-mono leading-relaxed mb-6">
-                                Non-negotiable knowledge for shipping code. Git, terminals, file structures, and the mental models that matter.
+                                The complete pattern library. Error logging, commands-as-apps, hooks, context hygiene, subagent control, tool stacks, and prompt engineering.
                             </p>
                             <div class="flex flex-wrap gap-2 text-xs">
-                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">git</span>
-                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">terminal</span>
-                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">debugging</span>
-                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">prompting</span>
+                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">feedback loops</span>
+                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">determinism</span>
+                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">context</span>
+                                <span class="px-2 py-1 bg-acid/10 text-acid border border-acid/20">safety</span>
                             </div>
                         </div>
 
                         <div class="bg-surface px-8 py-3 border-t border-white/10 flex justify-between items-center text-sm font-mono text-gray-600 group-hover:text-acid transition-colors">
-                            <span>LOAD_MODULE</span>
+                            <span>LOAD_LESSONS</span>
                             <span class="group-hover:translate-x-2 transition-transform">-></span>
                         </div>
                     </a>
 
-                    <!-- LEVEL UP Card -->
-                    <a href="level-up.html" class="group block border border-white/10 bg-panel hover:border-ice transition-all duration-300 relative overflow-hidden card-glow-ice">
+                    <!-- QUICK REFERENCE Card -->
+                    <a href="quick-reference.html" class="group block border border-white/10 bg-panel hover:border-ice transition-all duration-300 relative overflow-hidden card-glow-ice">
                         <!-- Corner accent -->
                         <div class="absolute top-0 left-0 w-16 h-16 border-l-2 border-t-2 border-ice/50 group-hover:border-ice transition-colors"></div>
                         <div class="absolute bottom-0 right-0 w-16 h-16 border-r-2 border-b-2 border-ice/50 group-hover:border-ice transition-colors"></div>
 
                         <!-- Icon -->
                         <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-ice">
-                            <i data-lucide="rocket" class="w-10 h-10"></i>
+                            <i data-lucide="table" class="w-10 h-10"></i>
                         </div>
 
                         <div class="p-8 relative">
                             <div class="text-xs text-ice font-mono mb-3 tracking-widest">:: MODULE_02</div>
                             <h3 class="font-display text-2xl md:text-3xl text-white font-bold mb-4 group-hover:text-ice transition-colors">
-                                LEVEL UP
+                                QUICK REFERENCE
                             </h3>
                             <p class="text-gray-500 font-mono leading-relaxed mb-6">
-                                Skills that will save you days. APIs, deployment, testing, and the techniques that separate shipping from struggling.
+                                Situation-action lookup tables. When Claude does something wrong, when context gets polluted, when you need reliable workflows.
                             </p>
                             <div class="flex flex-wrap gap-2 text-xs">
-                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">APIs</span>
-                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">deployment</span>
-                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">testing</span>
-                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">architecture</span>
+                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">debugging</span>
+                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">recovery</span>
+                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">workflows</span>
+                                <span class="px-2 py-1 bg-ice/10 text-ice border border-ice/20">optimization</span>
                             </div>
                         </div>
 
                         <div class="bg-surface px-8 py-3 border-t border-white/10 flex justify-between items-center text-sm font-mono text-gray-600 group-hover:text-ice transition-colors">
-                            <span>LOAD_MODULE</span>
+                            <span>VIEW_TABLES</span>
                             <span class="group-hover:translate-x-2 transition-transform">-></span>
                         </div>
                     </a>
@@ -210,79 +231,57 @@
                 </div>
             </section>
 
-            <!-- Resources Section -->
+            <!-- Skills Section -->
             <section>
                 <div class="border-b border-white/10 pb-4 mb-8">
                     <div class="flex items-end justify-between">
-                        <h2 class="font-display text-xl md:text-2xl text-white">// QUICK_ACCESS</h2>
-                        <span class="text-xs text-gray-600 font-mono hidden sm:inline">REFERENCE_TOOLS</span>
+                        <h2 class="font-display text-xl md:text-2xl text-white">// EXECUTABLE_SKILLS</h2>
+                        <span class="text-xs text-gray-600 font-mono hidden sm:inline">COPY_TO_PROJECT</span>
                     </div>
                 </div>
 
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
 
-                    <!-- GLOSSARY Card -->
-                    <a href="glossary.html" class="group block border border-white/10 bg-panel hover:border-signal transition-all duration-300 relative overflow-hidden card-glow-signal">
+                    <!-- /log_error Card -->
+                    <a href="skills.html#log-error" class="group block border border-white/10 bg-panel hover:border-signal transition-all duration-300 relative overflow-hidden card-glow-signal">
                         <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-signal">
-                            <i data-lucide="book-open" class="w-8 h-8"></i>
+                            <i data-lucide="bug" class="w-8 h-8"></i>
                         </div>
 
                         <div class="p-6">
-                            <div class="text-xs text-signal font-mono mb-2 tracking-widest">:: REFERENCE</div>
+                            <div class="text-xs text-signal font-mono mb-2 tracking-widest">:: SKILL</div>
                             <h3 class="font-display text-xl text-white font-bold mb-3 group-hover:text-signal transition-colors">
-                                GLOSSARY
+                                /log_error
                             </h3>
                             <p class="text-sm text-gray-500 font-mono leading-relaxed">
-                                Dev jargon decoded. Plain-language definitions for the terms you'll encounter while vibe coding.
+                                Systematic failure capture. Fork conversations, interview Claude about what went wrong, document the exact prompt that broke things.
                             </p>
                         </div>
 
                         <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-signal transition-colors">
-                            <span>ACCESS_DB</span>
+                            <span>VIEW_SKILL</span>
                             <span class="group-hover:translate-x-1 transition-transform">-></span>
                         </div>
                     </a>
 
-                    <!-- CHEAT SHEET Card -->
-                    <a href="cheat-sheet.html" class="group block border border-white/10 bg-panel hover:border-white transition-all duration-300 relative overflow-hidden card-glow-white">
-                        <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-white">
-                            <i data-lucide="file-text" class="w-8 h-8"></i>
+                    <!-- /log_success Card -->
+                    <a href="skills.html#log-success" class="group block border border-white/10 bg-panel hover:border-acid transition-all duration-300 relative overflow-hidden card-glow-acid">
+                        <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-acid">
+                            <i data-lucide="check-circle" class="w-8 h-8"></i>
                         </div>
 
                         <div class="p-6">
-                            <div class="text-xs text-gray-400 font-mono mb-2 tracking-widest">:: PRINTABLE</div>
-                            <h3 class="font-display text-xl text-white font-bold mb-3 group-hover:text-chrome transition-colors">
-                                CHEAT SHEET
+                            <div class="text-xs text-acid font-mono mb-2 tracking-widest">:: SKILL</div>
+                            <h3 class="font-display text-xl text-white font-bold mb-3 group-hover:text-acid transition-colors">
+                                /log_success
                             </h3>
                             <p class="text-sm text-gray-500 font-mono leading-relaxed">
-                                Print-friendly quick reference. Essential commands, keyboard shortcuts, and troubleshooting tips.
+                                Capture what works. Document effective prompts, extract generalizable templates, build a library of reliable patterns.
                             </p>
                         </div>
 
-                        <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-white transition-colors">
-                            <span>DOWNLOAD</span>
-                            <span class="group-hover:translate-x-1 transition-transform">-></span>
-                        </div>
-                    </a>
-
-                    <!-- COMMON MISTAKES Card -->
-                    <a href="common-mistakes.html" class="group block border border-white/10 bg-panel hover:border-signal transition-all duration-300 relative overflow-hidden card-glow-signal">
-                        <div class="absolute top-4 right-4 opacity-20 group-hover:opacity-100 transition-opacity text-signal">
-                            <i data-lucide="alert-triangle" class="w-8 h-8"></i>
-                        </div>
-
-                        <div class="p-6">
-                            <div class="text-xs text-signal font-mono mb-2 tracking-widest">:: DANGER_ZONE</div>
-                            <h3 class="font-display text-xl text-white font-bold mb-3 group-hover:text-signal transition-colors">
-                                COMMON MISTAKES
-                            </h3>
-                            <p class="text-sm text-gray-500 font-mono leading-relaxed">
-                                Avoid these pitfalls. Secrets in git, ignored errors, and other ways to break things.
-                            </p>
-                        </div>
-
-                        <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-signal transition-colors">
-                            <span>STAY_SAFE</span>
+                        <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-acid transition-colors">
+                            <span>VIEW_SKILL</span>
                             <span class="group-hover:translate-x-1 transition-transform">-></span>
                         </div>
                     </a>
@@ -290,22 +289,22 @@
                 </div>
             </section>
 
-            <!-- Philosophy callout -->
+            <!-- Context Warning -->
             <section class="mt-16 border border-white/10 bg-surface/50 p-6 md:p-8 relative">
                 <div class="absolute -top-3 left-6 bg-void px-3 text-xs text-gray-500 font-mono">
-                    SYSTEM_MESSAGE
+                    PERFORMANCE_NOTE
                 </div>
                 <div class="flex items-start gap-4">
-                    <div class="text-acid mt-1 hidden sm:block">
-                        <i data-lucide="terminal" class="w-6 h-6"></i>
+                    <div class="text-ice mt-1 hidden sm:block">
+                        <i data-lucide="gauge" class="w-6 h-6"></i>
                     </div>
                     <div>
                         <p class="text-gray-400 font-mono leading-relaxed mb-4">
-                            <span class="text-white">Vibe coding means learning by building</span> - you pick up programming concepts when your project needs them, not years before.
-                            AI handles the syntax; you handle the thinking.
+                            <span class="text-white">Models degrade ~50% at 50k tokens.</span>
+                            Context is finite. Every token must earn its place. These patterns help you stay lean and effective across long sessions.
                         </p>
                         <p class="text-sm text-gray-600 font-mono">
-                            // Build things. Break things. Fix them. Repeat.
+                            // Treat context like RAM. Clean it. Manage it. Respect its limits.
                         </p>
                     </div>
                 </div>
@@ -319,7 +318,7 @@
                 <div class="flex flex-col md:flex-row justify-between items-center gap-4">
                     <div class="text-center md:text-left">
                         <p class="text-gray-500 font-mono text-sm">
-                            <span class="text-acid">//</span> Start building. <span class="text-ice">The rest comes with practice.</span>
+                            <span class="text-signal">//</span> Build the feedback loops. <span class="text-acid">Make the model work for you.</span>
                         </p>
                     </div>
                     <div class="flex items-center gap-6 text-xs font-mono">
@@ -327,11 +326,11 @@
                             <i data-lucide="home" class="w-3 h-3"></i>
                             MAIN_HUB
                         </a>
-                        <a href="../code-patterns/index.html" class="text-gray-500 hover:text-signal transition-colors flex items-center gap-2">
-                            <i data-lucide="git-branch" class="w-3 h-3"></i>
-                            CODE_PATTERNS
+                        <a href="../vibe-coding/index.html" class="text-gray-500 hover:text-ice transition-colors flex items-center gap-2">
+                            <i data-lucide="terminal" class="w-3 h-3"></i>
+                            VIBE_CODING
                         </a>
-                        <a href="../llm-advisor/index.html" class="text-gray-500 hover:text-ice transition-colors flex items-center gap-2">
+                        <a href="../llm-advisor/index.html" class="text-gray-500 hover:text-signal transition-colors flex items-center gap-2">
                             <i data-lucide="bot" class="w-3 h-3"></i>
                             LLM_ADVISOR
                         </a>
@@ -342,7 +341,7 @@
                         AMDITIS_KIT v2.6 // Part of the <a href="../index.html" class="text-gray-500 hover:text-acid transition-colors hover-line">CCM Resource Collection</a>
                     </p>
                     <p class="text-xs text-gray-700 font-mono mt-2">
-                        Inspired by <a href="https://www.aihero.dev/creating-the-perfect-claude-code-status-line" class="text-gray-600 hover:text-acid transition-colors hover-line" target="_blank" rel="noopener">Matt Pocock's Claude Code status line guide</a>
+                        Source: <a href="https://github.com/jamditis/stash/tree/main/ai/claude-code-patterns" class="text-gray-600 hover:text-acid transition-colors hover-line" target="_blank" rel="noopener">Advanced Claude Code Patterns</a>
                     </p>
                 </div>
             </div>

--- a/resource-kit/docs/code-patterns/lessons.html
+++ b/resource-kit/docs/code-patterns/lessons.html
@@ -1,0 +1,717 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SEVEN LESSONS // CODE_PATTERNS</title>
+    <meta name="description" content="Seven core patterns for reliable Claude Code development. Error logging, commands-as-apps, hooks, context hygiene, subagent control, tool stacks, and prompt engineering.">
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+
+    <!-- CSS & Config -->
+    <link rel="stylesheet" href="../assets/amditis-main.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/amditis-config.js"></script>
+
+    <!-- Icons -->
+    <script src="https://unpkg.com/lucide@latest"></script>
+
+    <style>
+        .accordion-content {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s ease-out;
+        }
+        .accordion-content.open {
+            max-height: 3000px;
+        }
+        .accordion-chevron {
+            transition: transform 0.3s ease;
+        }
+        .accordion-chevron.rotated {
+            transform: rotate(180deg);
+        }
+        .lesson-number {
+            font-size: 4rem;
+            line-height: 1;
+            opacity: 0.1;
+            position: absolute;
+            right: 1rem;
+            top: 50%;
+            transform: translateY(-50%);
+            font-family: var(--font-display);
+            font-weight: 700;
+        }
+    </style>
+</head>
+<body class="antialiased font-mono bg-void text-chrome">
+
+    <div class="crt-overlay"></div>
+    <div class="fixed inset-0 bg-grid-pattern bg-[size:40px_40px] opacity-[0.07] pointer-events-none z-0"></div>
+
+    <div class="relative z-10 flex min-h-screen flex-col">
+
+        <!-- Header -->
+        <header class="border-b border-white/10 bg-panel/50 backdrop-blur-md sticky top-0 z-50">
+            <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+                <a href="index.html" class="flex items-center gap-3 group">
+                    <div class="w-8 h-8 bg-acid text-black flex items-center justify-center font-bold font-display text-xl clip-notch group-hover:bg-white transition-colors">A</div>
+                    <div>
+                        <div class="font-display font-bold text-sm tracking-wider text-chrome group-hover:text-acid transition-colors">SEVEN_LESSONS</div>
+                        <div class="text-xs text-gray-500 tracking-[0.2em]">CODE_PATTERNS</div>
+                    </div>
+                </a>
+                <nav class="flex gap-4 md:gap-6 text-xs font-mono">
+                    <a href="index.html" class="text-gray-400 hover:text-acid transition-colors flex items-center gap-2">
+                        <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                        <span class="hidden sm:inline">[ PATTERNS_HUB ]</span>
+                    </a>
+                </nav>
+            </div>
+        </header>
+
+        <!-- Main Content -->
+        <main class="flex-1 max-w-5xl mx-auto w-full px-6 py-12">
+
+            <!-- Page Header -->
+            <div class="mb-12">
+                <div class="text-xs text-acid font-mono mb-3 tracking-widest">:: MODULE_01</div>
+                <h1 class="font-display text-3xl md:text-4xl text-white font-bold mb-4">
+                    Seven core lessons
+                </h1>
+                <p class="text-gray-500 font-mono leading-relaxed max-w-2xl">
+                    Extracted from 2000+ hours of LLM development. Each lesson addresses a fundamental challenge in agentic workflows and provides actionable implementation steps.
+                </p>
+            </div>
+
+            <!-- Lessons Accordion -->
+            <div class="space-y-4">
+
+                <!-- Lesson 1: Error Logging System -->
+                <div class="border border-white/10 bg-panel" id="lesson-1">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-1')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-signal/10 text-signal text-xs font-mono border border-signal/20">LESSON_01</span>
+                                <i data-lucide="file-warning" class="w-4 h-4 text-signal"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold group-hover:text-acid">Error logging system</h3>
+                            <p class="text-sm text-gray-500 mt-2">Build feedback loops by capturing failures systematically</p>
+                        </div>
+                        <span class="lesson-number text-signal">01</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-1"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-1">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Problem -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// THE_PROBLEM</h4>
+                                <p class="text-gray-400 leading-relaxed">
+                                    When Claude makes a mistake, reconstructing what went wrong is difficult because the context, prompts, and execution path are ephemeral. Without systematic capture, you lose the ability to learn from failures.
+                                </p>
+                            </div>
+
+                            <!-- Five Failure Categories -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// FAILURE_CATEGORIES</h4>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Hallucination</span>
+                                        <p class="text-xs text-gray-500 mt-1">Generated false information</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Instruction ignored</span>
+                                        <p class="text-xs text-gray-500 mt-1">Neglected explicit directives</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Context lost</span>
+                                        <p class="text-xs text-gray-500 mt-1">Forgot prior conversation</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Wrong tool</span>
+                                        <p class="text-xs text-gray-500 mt-1">Applied incorrect methodology</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Incomplete execution</span>
+                                        <p class="text-xs text-gray-500 mt-1">Started but abandoned tasks</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Implementation -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// IMPLEMENTATION</h4>
+                                <ol class="space-y-3 text-gray-400">
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">1.</span>
+                                        <span><strong class="text-white">Develop logging commands</strong> that preserve conversation context and classify failures systematically</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">2.</span>
+                                        <span><strong class="text-white">Establish organized storage</strong> using <code class="text-signal bg-surface px-1">.claude/error-logs/</code> with timestamped entries</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">3.</span>
+                                        <span><strong class="text-white">Create success logging</strong> to identify which prompts consistently produce reliable results</span>
+                                    </li>
+                                </ol>
+                            </div>
+
+                            <!-- Key Insight -->
+                            <div class="p-4 bg-acidDim border border-acid/30">
+                                <p class="text-sm text-gray-300">
+                                    <span class="text-acid font-bold">KEY INSIGHT:</span> "The tightest feedback loops produce the fastest learning." Convert ephemeral failures into documented lessons.
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 2: Commands as Apps -->
+                <div class="border border-white/10 bg-panel" id="lesson-2">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-2')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-acid/10 text-acid text-xs font-mono border border-acid/20">LESSON_02</span>
+                                <i data-lucide="terminal-square" class="w-4 h-4 text-acid"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">/Commands as apps</h3>
+                            <p class="text-sm text-gray-500 mt-2">Deterministic triggers for sophisticated workflows</p>
+                        </div>
+                        <span class="lesson-number text-acid">02</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-2"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-2">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Core Concept -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// CORE_CONCEPT</h4>
+                                <p class="text-gray-400 leading-relaxed">
+                                    Slash commands transform Claude into a service platform. They're <strong class="text-white">deterministic triggers</strong> for multi-step operations—not probabilistic natural language requests. The intelligence lives in the skill, but you get reliable execution through the command.
+                                </p>
+                            </div>
+
+                            <!-- Capabilities -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// CAPABILITIES</h4>
+                                <ul class="space-y-2 text-gray-400">
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-ice"></i>
+                                        Launch parallel subagents for concurrent work
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-ice"></i>
+                                        Access files, repositories, and browsers
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-ice"></i>
+                                        Chain multiple operations together
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-ice"></i>
+                                        Route to different models based on task requirements
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Implementation -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// IMPLEMENTATION</h4>
+                                <ol class="space-y-3 text-gray-400">
+                                    <li class="flex gap-3">
+                                        <span class="text-signal font-mono">1.</span>
+                                        <span><strong class="text-white">Identify repetitive workflows</strong> with multiple consistent steps</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-signal font-mono">2.</span>
+                                        <span><strong class="text-white">Design simple interfaces</strong> with memorable command names</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-signal font-mono">3.</span>
+                                        <span><strong class="text-white">Create command files</strong> in <code class="text-acid bg-surface px-1">.claude/commands/</code></span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-signal font-mono">4.</span>
+                                        <span><strong class="text-white">Consider model routing</strong> for optimal performance across phases</span>
+                                    </li>
+                                </ol>
+                            </div>
+
+                            <!-- Example -->
+                            <div class="p-4 bg-surface border border-white/10">
+                                <p class="text-xs text-gray-500 font-mono mb-2">// EXAMPLE</p>
+                                <p class="text-sm text-gray-300">
+                                    A <code class="text-acid">/presentation-to-shorts</code> command can replace "what would traditionally require a content analysis tool, a project management system, multiple team handoffs, and hours of coordination."
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 3: Hooks for Safety -->
+                <div class="border border-white/10 bg-panel" id="lesson-3">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-3')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-signal/10 text-signal text-xs font-mono border border-signal/20">LESSON_03</span>
+                                <i data-lucide="shield" class="w-4 h-4 text-signal"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">Hooks for safety</h3>
+                            <p class="text-sm text-gray-500 mt-2">Programmatic guardrails that run before/after actions</p>
+                        </div>
+                        <span class="lesson-number text-signal">03</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-3"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-3">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Problem & Solution -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// PROBLEM_&_SOLUTION</h4>
+                                <p class="text-gray-400 leading-relaxed mb-4">
+                                    Permission prompts exist for safety but disrupt workflow continuity. Rather than removing all safeguards through <code class="text-signal bg-surface px-1">--dangerously-skip-permissions</code> alone, combine this flag with hook-based validation for <strong class="text-white">autonomous operation within safe boundaries</strong>.
+                                </p>
+                            </div>
+
+                            <!-- Implementation -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// IMPLEMENTATION</h4>
+                                <ol class="space-y-3 text-gray-400">
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">1.</span>
+                                        <span><strong class="text-white">Identify constraints</strong> — operations that should never execute autonomously (recursive deletions, force pushes, production config changes)</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">2.</span>
+                                        <span><strong class="text-white">Deploy pre-execution hooks</strong> — create bash scripts in <code class="text-acid bg-surface px-1">.claude/hooks/</code></span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">3.</span>
+                                        <span><strong class="text-white">Register hooks</strong> — configure through JSON settings</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-ice font-mono">4.</span>
+                                        <span><strong class="text-white">Validate thoroughly</strong> — test blocked patterns intentionally</span>
+                                    </li>
+                                </ol>
+                            </div>
+
+                            <!-- Code Example -->
+                            <div class="mb-6 bg-surface border border-white/10 p-4">
+                                <p class="text-xs text-gray-500 font-mono mb-2">// EXAMPLE: Block dangerous rm operations</p>
+                                <pre class="text-sm text-gray-300 overflow-x-auto"><code>if echo "$COMMAND" | grep -qE "rm\s+(-rf|-fr|--recursive).*(/|~|\$HOME)"; then
+    echo "BLOCKED"
+fi</code></pre>
+                            </div>
+
+                            <!-- Key Insight -->
+                            <div class="p-4 bg-signalDim border border-signal/30">
+                                <p class="text-sm text-gray-300">
+                                    <span class="text-signal font-bold">KEY INSIGHT:</span> Programmatic control through deterministic code rules creates superior outcomes compared to relying solely on probabilistic model guidance.
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 4: Context Hygiene -->
+                <div class="border border-white/10 bg-panel" id="lesson-4">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-4')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-ice/10 text-ice text-xs font-mono border border-ice/20">LESSON_04</span>
+                                <i data-lucide="eraser" class="w-4 h-4 text-ice"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">Context hygiene</h3>
+                            <p class="text-sm text-gray-500 mt-2">Keep context clean—models degrade 50%+ at 50k tokens</p>
+                        </div>
+                        <span class="lesson-number text-ice">04</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-4"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-4">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Warning Signs -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// WARNING_SIGNS</h4>
+                                <ul class="space-y-2 text-gray-400">
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="alert-circle" class="w-4 h-4 text-signal"></i>
+                                        Multiple unrelated projects in one session
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="alert-circle" class="w-4 h-4 text-signal"></i>
+                                        Forgotten instructions in CLAUDE.md
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="alert-circle" class="w-4 h-4 text-signal"></i>
+                                        CLAUDE.md files exceeding 50 lines
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="alert-circle" class="w-4 h-4 text-signal"></i>
+                                        Claude referencing stale earlier discussions
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="alert-circle" class="w-4 h-4 text-signal"></i>
+                                        Declining response quality over longer sessions
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Compaction Strategies -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// COMPACTION_STRATEGIES</h4>
+                                <div class="space-y-3">
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Manual compaction control</span>
+                                        <p class="text-xs text-gray-500 mt-1">Disable automatic compaction, display context usage status</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Clear breakpoints</span>
+                                        <p class="text-xs text-gray-500 mt-1">Use <code class="text-acid">/clear</code> with repo-specific config between work contexts</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Orchestrator pattern</span>
+                                        <p class="text-xs text-gray-500 mt-1">Assign Claude as coordinator launching specialized subagents for isolated tasks</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Strategic manual compaction</span>
+                                        <p class="text-xs text-gray-500 mt-1">Invoke <code class="text-acid">/compact</code> at appropriate boundaries</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Custom handoff command</span>
+                                        <p class="text-xs text-gray-500 mt-1">Implement <code class="text-acid">/handoff {NOTES}</code> for clean session transitions</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Double-Escape -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// DOUBLE_ESCAPE_TIME_TRAVEL</h4>
+                                <p class="text-gray-400 leading-relaxed mb-3">
+                                    A powerful but underutilized feature allowing conversation restoration:
+                                </p>
+                                <ul class="space-y-2 text-gray-400">
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="rotate-ccw" class="w-4 h-4 text-ice"></i>
+                                        <strong class="text-white">Conversation-only restore:</strong> Clean polluted discussions, preserve code
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="rotate-ccw" class="w-4 h-4 text-ice"></i>
+                                        <strong class="text-white">Full restore:</strong> Revert both conversation and code to previous state
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Key Insight -->
+                            <div class="p-4 bg-iceDim border border-ice/30">
+                                <p class="text-sm text-gray-300">
+                                    <span class="text-ice font-bold">KEY INSIGHT:</span> Treat context as a finite resource. Irrelevant tokens actively impair performance. Rigorous hygiene practices significantly enhance results.
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 5: Subagent Control -->
+                <div class="border border-white/10 bg-panel" id="lesson-5">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-5')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-acid/10 text-acid text-xs font-mono border border-acid/20">LESSON_05</span>
+                                <i data-lucide="network" class="w-4 h-4 text-acid"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">Subagent control</h3>
+                            <p class="text-sm text-gray-500 mt-2">Match model capability to task demands</p>
+                        </div>
+                        <span class="lesson-number text-acid">05</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-5"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-5">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Core Problem -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// DEFAULT_BEHAVIOR</h4>
+                                <p class="text-gray-400 leading-relaxed">
+                                    Claude spawns Sonnet or Haiku subagents by default, even for knowledge-intensive tasks that would benefit from more capable models. You must take explicit control over subagent selection.
+                                </p>
+                            </div>
+
+                            <!-- Actionable Steps -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// ACTIONABLE_STEPS</h4>
+                                <ol class="space-y-3 text-gray-400">
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">1.</span>
+                                        <span><strong class="text-white">Force Opus for complex tasks</strong> — Add "Always launch opus subagents" to config for knowledge-intensive work</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">2.</span>
+                                        <span><strong class="text-white">Monitor activity</strong> — Track which subagents spawn, their tasks, and completion status</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">3.</span>
+                                        <span><strong class="text-white">Keep tasks focused</strong> — One clear objective per subagent with well-defined inputs/outputs</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">4.</span>
+                                        <span><strong class="text-white">Parallelize work</strong> — Spawn multiple independent subagents to maintain clean contexts</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">5.</span>
+                                        <span><strong class="text-white">Prioritize quantity over load</strong> — More subagents >> More tasks per subagent</span>
+                                    </li>
+                                </ol>
+                            </div>
+
+                            <!-- Critical Warnings -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// CRITICAL_WARNINGS</h4>
+                                <div class="space-y-3">
+                                    <div class="p-3 bg-signalDim border border-signal/30">
+                                        <span class="text-signal text-sm font-bold">Hallucination chains</span>
+                                        <p class="text-xs text-gray-400 mt-1">Subagent-to-subagent info passing can compound errors. Use deterministic verification between handoffs.</p>
+                                    </div>
+                                    <div class="p-3 bg-signalDim border border-signal/30">
+                                        <span class="text-signal text-sm font-bold">Subagent overload</span>
+                                        <p class="text-xs text-gray-400 mt-1">Multiple unrelated tasks create context pollution. Split into separate focused agents.</p>
+                                    </div>
+                                    <div class="p-3 bg-signalDim border border-signal/30">
+                                        <span class="text-signal text-sm font-bold">Model mismatch</span>
+                                        <p class="text-xs text-gray-400 mt-1">Complex reasoning delegated to lighter models produces inferior results.</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 6: Lean Tool Stack -->
+                <div class="border border-white/10 bg-panel" id="lesson-6">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-6')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-ice/10 text-ice text-xs font-mono border border-ice/20">LESSON_06</span>
+                                <i data-lucide="layers" class="w-4 h-4 text-ice"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">Lean tool stack</h3>
+                            <p class="text-sm text-gray-500 mt-2">Every token must fight for its place</p>
+                        </div>
+                        <span class="lesson-number text-ice">06</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-6"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-6">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Core Principle -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// CORE_PRINCIPLE</h4>
+                                <p class="text-gray-400 leading-relaxed">
+                                    Context windows are finite resources. Rather than accumulating tools, ruthlessly evaluate whether each integration genuinely justifies its token consumption.
+                                </p>
+                            </div>
+
+                            <!-- Recommended Tools -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// RECOMMENDED_ESSENTIALS</h4>
+                                <div class="space-y-3">
+                                    <div class="p-4 bg-surface border border-white/10">
+                                        <div class="flex items-center gap-2 mb-2">
+                                            <i data-lucide="book-open" class="w-4 h-4 text-ice"></i>
+                                            <span class="text-white font-bold">Context7 MCP</span>
+                                        </div>
+                                        <p class="text-sm text-gray-400">Provides current framework documentation. Prevents reliance on outdated training data and reduces API hallucinations.</p>
+                                    </div>
+                                    <div class="p-4 bg-surface border border-white/10">
+                                        <div class="flex items-center gap-2 mb-2">
+                                            <i data-lucide="globe" class="w-4 h-4 text-ice"></i>
+                                            <span class="text-white font-bold">Dev Browser / Playwright MCP</span>
+                                        </div>
+                                        <p class="text-sm text-gray-400">Enables browser automation and visual debugging. Dev Browser is preferable for faster execution.</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Implementation Strategy -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// IMPLEMENTATION</h4>
+                                <ul class="space-y-2 text-gray-400">
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-acid"></i>
+                                        Audit existing tools weekly to identify unused integrations
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-acid"></i>
+                                        Evaluate whether new tools warrant the overhead
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-acid"></i>
+                                        Start minimally with only Context7 and Dev Browser
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-acid"></i>
+                                        Monitor when context limitations actually emerge
+                                    </li>
+                                    <li class="flex items-center gap-2">
+                                        <i data-lucide="check" class="w-4 h-4 text-acid"></i>
+                                        Leverage Claude's native capabilities before seeking MCPs
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Key Insight -->
+                            <div class="p-4 bg-iceDim border border-ice/30">
+                                <p class="text-sm text-gray-300">
+                                    <span class="text-ice font-bold">KEY INSIGHT:</span> Constraint as opportunity—a streamlined toolkit preserves context capacity for actual problem-solving.
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Lesson 7: Prompt Engineering -->
+                <div class="border border-white/10 bg-panel" id="lesson-7">
+                    <button class="accordion-trigger w-full p-6 text-left flex items-center justify-between relative hover:bg-surface/50 transition-colors" onclick="toggleAccordion('lesson-7')">
+                        <div class="pr-16">
+                            <div class="flex items-center gap-3 mb-2">
+                                <span class="px-2 py-1 bg-signal/10 text-signal text-xs font-mono border border-signal/20">LESSON_07</span>
+                                <i data-lucide="mic" class="w-4 h-4 text-signal"></i>
+                            </div>
+                            <h3 class="font-display text-xl text-white font-bold">Prompt engineering on steroids</h3>
+                            <p class="text-sm text-gray-500 mt-2">Voice input + automated enhancement systems</p>
+                        </div>
+                        <span class="lesson-number text-signal">07</span>
+                        <i data-lucide="chevron-down" class="w-5 h-5 text-gray-500 accordion-chevron" id="chevron-lesson-7"></i>
+                    </button>
+                    <div class="accordion-content" id="content-lesson-7">
+                        <div class="p-6 pt-0 border-t border-white/10">
+
+                            <!-- Two Observations -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-signal font-mono mb-3">// TWO_OBSERVATIONS</h4>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                    <div class="p-4 bg-surface border border-white/10">
+                                        <span class="text-white font-bold block mb-2">Speaking is 3-4x faster</span>
+                                        <p class="text-sm text-gray-400">Voice captures nuance better than typing for most people</p>
+                                    </div>
+                                    <div class="p-4 bg-surface border border-white/10">
+                                        <span class="text-white font-bold block mb-2">Automation potential</span>
+                                        <p class="text-sm text-gray-400">Prompt engineering follows repeatable patterns with templatable structures</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Reprompter System -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-acid font-mono mb-3">// REPROMPTER_WORKFLOW</h4>
+                                <ol class="space-y-2 text-gray-400">
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">1.</span>
+                                        <span>Activate via keybind</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">2.</span>
+                                        <span>Dictate requirements verbally</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">3.</span>
+                                        <span>System poses clarifying questions</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">4.</span>
+                                        <span>Provide voice answers</span>
+                                    </li>
+                                    <li class="flex gap-3">
+                                        <span class="text-acid font-mono">5.</span>
+                                        <span>Automated generation of structured prompt with XML tags, role assignments, embedded best practices</span>
+                                    </li>
+                                </ol>
+                            </div>
+
+                            <!-- Alternative Approaches -->
+                            <div class="mb-6">
+                                <h4 class="text-sm text-ice font-mono mb-3">// ALTERNATIVE_APPROACHES</h4>
+                                <div class="space-y-3">
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Option 1: Reprompter system</span>
+                                        <p class="text-xs text-gray-500 mt-1">Voice capture + global keybind + template-based enhancement + fast model processing</p>
+                                    </div>
+                                    <div class="p-3 bg-surface border border-white/5">
+                                        <span class="text-white text-sm font-bold">Option 2: Model interviews</span>
+                                        <p class="text-xs text-gray-500 mt-1">"Instead of trying to write the perfect prompt upfront, ask the model to interview you about what you want"</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Key Insight -->
+                            <div class="p-4 bg-signalDim border border-signal/30">
+                                <p class="text-sm text-gray-300">
+                                    <span class="text-signal font-bold">KEY INSIGHT:</span> Eliminate manual prompt typing. Leverage voice input or conversational interviews to focus on solving actual problems instead of formatting.
+                                </p>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+        </main>
+
+        <!-- Footer -->
+        <footer class="border-t border-white/10 bg-panel/50 mt-auto">
+            <div class="max-w-5xl mx-auto px-6 py-8">
+                <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                    <div class="text-center md:text-left">
+                        <p class="text-gray-500 font-mono text-sm">
+                            <span class="text-acid">//</span> Apply one pattern at a time. <span class="text-ice">Build the habits that compound.</span>
+                        </p>
+                    </div>
+                    <div class="flex items-center gap-6 text-xs font-mono">
+                        <a href="index.html" class="text-gray-500 hover:text-acid transition-colors flex items-center gap-2">
+                            <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                            PATTERNS_HUB
+                        </a>
+                        <a href="quick-reference.html" class="text-gray-500 hover:text-ice transition-colors flex items-center gap-2">
+                            <i data-lucide="table" class="w-3 h-3"></i>
+                            QUICK_REF
+                        </a>
+                        <a href="skills.html" class="text-gray-500 hover:text-signal transition-colors flex items-center gap-2">
+                            <i data-lucide="terminal" class="w-3 h-3"></i>
+                            SKILLS
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+    </div>
+
+    <script>
+        // Initialize Lucide icons
+        lucide.createIcons();
+
+        // Accordion functionality
+        function toggleAccordion(lessonId) {
+            const content = document.getElementById('content-' + lessonId);
+            const chevron = document.getElementById('chevron-' + lessonId);
+
+            content.classList.toggle('open');
+            chevron.classList.toggle('rotated');
+        }
+
+        // Open first accordion by default
+        document.addEventListener('DOMContentLoaded', function() {
+            toggleAccordion('lesson-1');
+        });
+    </script>
+</body>
+</html>

--- a/resource-kit/docs/code-patterns/quick-reference.html
+++ b/resource-kit/docs/code-patterns/quick-reference.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>QUICK REFERENCE // CODE_PATTERNS</title>
+    <meta name="description" content="Situation-action lookup tables for Claude Code. Quick reference for debugging, workflows, recovery, and optimization.">
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+
+    <!-- CSS & Config -->
+    <link rel="stylesheet" href="../assets/amditis-main.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/amditis-config.js"></script>
+
+    <!-- Icons -->
+    <script src="https://unpkg.com/lucide@latest"></script>
+
+    <style>
+        .ref-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .ref-table th {
+            text-align: left;
+            padding: 0.75rem 1rem;
+            background: rgba(17, 17, 17, 0.8);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+        .ref-table td {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            vertical-align: top;
+        }
+        .ref-table tr:hover {
+            background: rgba(255, 255, 255, 0.02);
+        }
+        .situation-cell {
+            color: #e8e8e8;
+            font-weight: 500;
+        }
+        .action-cell {
+            font-family: monospace;
+        }
+
+        @media print {
+            body { background: white; color: black; }
+            .no-print { display: none; }
+            .ref-table th { background: #f0f0f0; }
+            .ref-table td { border-color: #ccc; }
+        }
+    </style>
+</head>
+<body class="antialiased font-mono bg-void text-chrome">
+
+    <div class="crt-overlay no-print"></div>
+    <div class="fixed inset-0 bg-grid-pattern bg-[size:40px_40px] opacity-[0.07] pointer-events-none z-0 no-print"></div>
+
+    <div class="relative z-10 flex min-h-screen flex-col">
+
+        <!-- Header -->
+        <header class="border-b border-white/10 bg-panel/50 backdrop-blur-md sticky top-0 z-50 no-print">
+            <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+                <a href="index.html" class="flex items-center gap-3 group">
+                    <div class="w-8 h-8 bg-ice text-black flex items-center justify-center font-bold font-display text-xl clip-notch group-hover:bg-white transition-colors">A</div>
+                    <div>
+                        <div class="font-display font-bold text-sm tracking-wider text-chrome group-hover:text-ice transition-colors">QUICK_REFERENCE</div>
+                        <div class="text-xs text-gray-500 tracking-[0.2em]">CODE_PATTERNS</div>
+                    </div>
+                </a>
+                <nav class="flex gap-4 md:gap-6 text-xs font-mono">
+                    <button onclick="window.print()" class="text-gray-400 hover:text-ice transition-colors flex items-center gap-2">
+                        <i data-lucide="printer" class="w-3 h-3"></i>
+                        <span class="hidden sm:inline">[ PRINT ]</span>
+                    </button>
+                    <a href="index.html" class="text-gray-400 hover:text-acid transition-colors flex items-center gap-2">
+                        <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                        <span class="hidden sm:inline">[ PATTERNS_HUB ]</span>
+                    </a>
+                </nav>
+            </div>
+        </header>
+
+        <!-- Main Content -->
+        <main class="flex-1 max-w-5xl mx-auto w-full px-6 py-12">
+
+            <!-- Page Header -->
+            <div class="mb-12">
+                <div class="text-xs text-ice font-mono mb-3 tracking-widest">:: MODULE_02</div>
+                <h1 class="font-display text-3xl md:text-4xl text-white font-bold mb-4">
+                    Quick reference tables
+                </h1>
+                <p class="text-gray-500 font-mono leading-relaxed max-w-2xl">
+                    Situation-action lookup for common Claude Code scenarios. Find your situation, apply the recommended action.
+                </p>
+            </div>
+
+            <!-- Reference Tables -->
+            <div class="space-y-12">
+
+                <!-- Debugging & Logging -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="bug" class="w-5 h-5 text-signal"></i>
+                        <h2 class="font-display text-xl text-white">Debugging & logging</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Claude does something wrong</td>
+                                    <td class="action-cell text-gray-400">
+                                        <code class="text-acid">/log_error</code> → fork → interview → capture verbatim prompt → rewind
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Claude does something right</td>
+                                    <td class="action-cell text-gray-400">
+                                        <code class="text-acid">/log_success</code> → capture prompt → extract template → consider promoting to CLAUDE.md
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Same error keeps recurring</td>
+                                    <td class="action-cell text-gray-400">
+                                        Review error logs → identify pattern → create hook or add to CLAUDE.md
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Claude hallucinating APIs</td>
+                                    <td class="action-cell text-gray-400">
+                                        Use <code class="text-ice">Context7 MCP</code> for current documentation → category: hallucination
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Workflow Execution -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="play-circle" class="w-5 h-5 text-acid"></i>
+                        <h2 class="font-display text-xl text-white">Workflow execution</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Need reliable workflow execution</td>
+                                    <td class="action-cell text-gray-400">
+                                        Use <code class="text-acid">/command</code> with deterministic wrapping, not natural language
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Repetitive multi-step task</td>
+                                    <td class="action-cell text-gray-400">
+                                        Create command in <code class="text-ice">.claude/commands/</code> → document purpose + workflow
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Different phases need different models</td>
+                                    <td class="action-cell text-gray-400">
+                                        Implement model routing in command definition
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Tasks can run in parallel</td>
+                                    <td class="action-cell text-gray-400">
+                                        Design command to spawn independent subagents → maintain isolated contexts
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Permission & Context Management -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="shield" class="w-5 h-5 text-ice"></i>
+                        <h2 class="font-display text-xl text-white">Permission & context management</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Claude requesting excessive permissions</td>
+                                    <td class="action-cell text-gray-400">
+                                        Implement hooks + <code class="text-signal">--dangerously-skip-permissions</code> for safe autonomy
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Need to block dangerous operations</td>
+                                    <td class="action-cell text-gray-400">
+                                        Create pre-execution hooks in <code class="text-ice">.claude/hooks/</code> → pattern match blocked commands
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Context getting bloated</td>
+                                    <td class="action-cell text-gray-400">
+                                        Use <code class="text-acid">/compact</code> at natural boundaries → consider subagent delegation
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">CLAUDE.md exceeds 50 lines</td>
+                                    <td class="action-cell text-gray-400">
+                                        Audit weekly → move rarely-used instructions to skills → keep only essentials
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Switching between projects</td>
+                                    <td class="action-cell text-gray-400">
+                                        <code class="text-acid">/clear</code> with repo-specific config → clean context transition
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Recovery & Restoration -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="rotate-ccw" class="w-5 h-5 text-signal"></i>
+                        <h2 class="font-display text-xl text-white">Recovery & restoration</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Bugs polluted the context</td>
+                                    <td class="action-cell text-gray-400">
+                                        Double-escape → restore conversation only (preserves correct code)
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Need full rollback</td>
+                                    <td class="action-cell text-gray-400">
+                                        Double-escape → full restore (reverts conversation + code)
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Claude going in circles</td>
+                                    <td class="action-cell text-gray-400">
+                                        Fork conversation → rephrase approach → try different angle
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Ending session cleanly</td>
+                                    <td class="action-cell text-gray-400">
+                                        <code class="text-acid">/handoff {NOTES}</code> → explicit priority notes for next session
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Multi-Agent Patterns -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="network" class="w-5 h-5 text-acid"></i>
+                        <h2 class="font-display text-xl text-white">Multi-agent patterns</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Complex reasoning task</td>
+                                    <td class="action-cell text-gray-400">
+                                        Force Opus subagent → add "Always launch opus subagents" to config
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Subagent producing poor results</td>
+                                    <td class="action-cell text-gray-400">
+                                        Check model selection → likely model mismatch → upgrade to Opus
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Errors compounding across agents</td>
+                                    <td class="action-cell text-gray-400">
+                                        Implement deterministic verification between handoffs → don't trust claims
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Subagent handling too many tasks</td>
+                                    <td class="action-cell text-gray-400">
+                                        Split into multiple focused agents → one objective per agent
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <!-- Input Optimization -->
+                <section>
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-white/10">
+                        <i data-lucide="mic" class="w-5 h-5 text-ice"></i>
+                        <h2 class="font-display text-xl text-white">Input optimization</h2>
+                    </div>
+                    <div class="border border-white/10 bg-panel overflow-hidden overflow-x-auto">
+                        <table class="ref-table">
+                            <thead>
+                                <tr>
+                                    <th class="text-signal w-2/5">Situation</th>
+                                    <th class="text-acid">Recommended action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="situation-cell">Typing prompts feels slow</td>
+                                    <td class="action-cell text-gray-400">
+                                        Use reprompter tool → voice input → automated structure → keybind activation
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Unsure what to ask for</td>
+                                    <td class="action-cell text-gray-400">
+                                        Model interview approach → "Interview me about what I want" → let model surface requirements
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Prompt too vague</td>
+                                    <td class="action-cell text-gray-400">
+                                        Add XML structure → role assignment → specific examples → clear constraints
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="situation-cell">Same prompt type needed repeatedly</td>
+                                    <td class="action-cell text-gray-400">
+                                        Extract template → store in success logs → promote to skill if valuable
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+            </div>
+
+        </main>
+
+        <!-- Footer -->
+        <footer class="border-t border-white/10 bg-panel/50 mt-auto no-print">
+            <div class="max-w-5xl mx-auto px-6 py-8">
+                <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                    <div class="text-center md:text-left">
+                        <p class="text-gray-500 font-mono text-sm">
+                            <span class="text-ice">//</span> Find the situation. <span class="text-acid">Apply the action.</span>
+                        </p>
+                    </div>
+                    <div class="flex items-center gap-6 text-xs font-mono">
+                        <a href="index.html" class="text-gray-500 hover:text-acid transition-colors flex items-center gap-2">
+                            <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                            PATTERNS_HUB
+                        </a>
+                        <a href="lessons.html" class="text-gray-500 hover:text-ice transition-colors flex items-center gap-2">
+                            <i data-lucide="graduation-cap" class="w-3 h-3"></i>
+                            LESSONS
+                        </a>
+                        <a href="skills.html" class="text-gray-500 hover:text-signal transition-colors flex items-center gap-2">
+                            <i data-lucide="terminal" class="w-3 h-3"></i>
+                            SKILLS
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+    </div>
+
+    <script>
+        // Initialize Lucide icons
+        lucide.createIcons();
+    </script>
+</body>
+</html>

--- a/resource-kit/docs/code-patterns/skills.html
+++ b/resource-kit/docs/code-patterns/skills.html
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EXECUTABLE SKILLS // CODE_PATTERNS</title>
+    <meta name="description" content="Copy-paste skills for Claude Code. /log_error and /log_success commands for systematic feedback loops.">
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+
+    <!-- CSS & Config -->
+    <link rel="stylesheet" href="../assets/amditis-main.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../assets/amditis-config.js"></script>
+
+    <!-- Icons -->
+    <script src="https://unpkg.com/lucide@latest"></script>
+
+    <style>
+        .code-block {
+            position: relative;
+        }
+        .copy-btn {
+            position: absolute;
+            top: 0.5rem;
+            right: 0.5rem;
+            opacity: 0;
+            transition: opacity 0.2s;
+        }
+        .code-block:hover .copy-btn {
+            opacity: 1;
+        }
+        .copy-btn.copied {
+            opacity: 1;
+        }
+    </style>
+</head>
+<body class="antialiased font-mono bg-void text-chrome">
+
+    <div class="crt-overlay"></div>
+    <div class="fixed inset-0 bg-grid-pattern bg-[size:40px_40px] opacity-[0.07] pointer-events-none z-0"></div>
+
+    <div class="relative z-10 flex min-h-screen flex-col">
+
+        <!-- Header -->
+        <header class="border-b border-white/10 bg-panel/50 backdrop-blur-md sticky top-0 z-50">
+            <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
+                <a href="index.html" class="flex items-center gap-3 group">
+                    <div class="w-8 h-8 bg-signal text-black flex items-center justify-center font-bold font-display text-xl clip-notch group-hover:bg-white transition-colors">A</div>
+                    <div>
+                        <div class="font-display font-bold text-sm tracking-wider text-chrome group-hover:text-signal transition-colors">SKILLS</div>
+                        <div class="text-xs text-gray-500 tracking-[0.2em]">CODE_PATTERNS</div>
+                    </div>
+                </a>
+                <nav class="flex gap-4 md:gap-6 text-xs font-mono">
+                    <a href="index.html" class="text-gray-400 hover:text-acid transition-colors flex items-center gap-2">
+                        <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                        <span class="hidden sm:inline">[ PATTERNS_HUB ]</span>
+                    </a>
+                </nav>
+            </div>
+        </header>
+
+        <!-- Main Content -->
+        <main class="flex-1 max-w-5xl mx-auto w-full px-6 py-12">
+
+            <!-- Page Header -->
+            <div class="mb-12">
+                <div class="text-xs text-signal font-mono mb-3 tracking-widest">:: EXECUTABLE_SKILLS</div>
+                <h1 class="font-display text-3xl md:text-4xl text-white font-bold mb-4">
+                    Feedback loop skills
+                </h1>
+                <p class="text-gray-500 font-mono leading-relaxed max-w-2xl">
+                    Copy these skill definitions into your <code class="text-acid">.claude/skills/</code> directory. They implement the error and success logging patterns from Lesson 01.
+                </p>
+            </div>
+
+            <!-- Usage Instructions -->
+            <div class="mb-12 p-6 bg-surface border border-white/10">
+                <h3 class="text-sm text-acid font-mono mb-4">// SETUP_INSTRUCTIONS</h3>
+                <ol class="space-y-3 text-gray-400">
+                    <li class="flex gap-3">
+                        <span class="text-acid font-mono">1.</span>
+                        <span>Create <code class="text-ice bg-panel px-1">.claude/skills/</code> directory in your project root</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-acid font-mono">2.</span>
+                        <span>Create <code class="text-ice bg-panel px-1">.claude/error-logs/</code> directory for log storage</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-acid font-mono">3.</span>
+                        <span>Copy each skill below into its own <code class="text-ice bg-panel px-1">.md</code> file</span>
+                    </li>
+                    <li class="flex gap-3">
+                        <span class="text-acid font-mono">4.</span>
+                        <span>Invoke with <code class="text-acid bg-panel px-1">/log_error</code> or <code class="text-acid bg-panel px-1">/log_success</code> when needed</span>
+                    </li>
+                </ol>
+            </div>
+
+            <!-- Skills -->
+            <div class="space-y-12">
+
+                <!-- /log_error Skill -->
+                <section id="log-error">
+                    <div class="flex items-center gap-3 mb-6">
+                        <div class="p-2 bg-signal/10 border border-signal/30">
+                            <i data-lucide="bug" class="w-6 h-6 text-signal"></i>
+                        </div>
+                        <div>
+                            <h2 class="font-display text-2xl text-white font-bold">/log_error</h2>
+                            <p class="text-sm text-gray-500">Systematic failure capture and analysis</p>
+                        </div>
+                    </div>
+
+                    <!-- Purpose -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-signal font-mono mb-3">// PURPOSE</h3>
+                        <p class="text-gray-400 leading-relaxed">
+                            When Claude makes a mistake, this skill guides you through a structured process to capture what went wrong, why it happened, and how to prevent it in the future. The key is capturing the <strong class="text-white">exact prompt wording</strong>, not a paraphrase.
+                        </p>
+                    </div>
+
+                    <!-- Workflow -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-ice font-mono mb-3">// WORKFLOW</h3>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-ice font-display font-bold">1</span>
+                                <p class="text-xs text-gray-400 mt-2">Fork conversation (create checkpoint)</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-ice font-display font-bold">2</span>
+                                <p class="text-xs text-gray-400 mt-2">Interview Claude about the failure</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-ice font-display font-bold">3</span>
+                                <p class="text-xs text-gray-400 mt-2">Document exact prompt</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-ice font-display font-bold">4</span>
+                                <p class="text-xs text-gray-400 mt-2">Rewind to pre-error state</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Skill Definition -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-acid font-mono mb-3">// SKILL_DEFINITION</h3>
+                        <p class="text-xs text-gray-500 mb-2">Save as: <code class="text-acid">.claude/skills/log-error.md</code></p>
+                        <div class="code-block border border-white/10 bg-panel">
+                            <button class="copy-btn px-3 py-1 bg-acid/10 text-acid text-xs border border-acid/30 hover:bg-acid hover:text-black transition-colors" onclick="copyCode(this, 'log-error-code')">
+                                <i data-lucide="copy" class="w-3 h-3 inline"></i> Copy
+                            </button>
+                            <pre class="p-4 text-sm text-gray-300 overflow-x-auto" id="log-error-code"><code># /log_error
+
+Systematic error capture for building feedback loops.
+
+## Trigger
+Invoke when Claude produces incorrect output, misses instructions, or behaves unexpectedly.
+
+## Workflow
+
+### Step 1: Create Checkpoint
+Fork the conversation to preserve the error state before investigating.
+
+### Step 2: Root Cause Interview
+Ask Claude:
+- "What prompt or instruction triggered this behavior?"
+- "What did you think I was asking for?"
+- "What context were you missing?"
+
+### Step 3: Document the Failure
+Create log entry in `.claude/error-logs/` with timestamp:
+
+```markdown
+## Error Log: [YYYY-MM-DD-HHMM]
+
+**Context:** [What were you trying to accomplish?]
+
+**Incorrect Behavior:** [What Claude did wrong]
+
+**Exact Prompt (verbatim, not paraphrased):**
+> [Copy the exact text you sent]
+
+**What Claude Misunderstood:** [The gap between intent and interpretation]
+
+**Root Cause Category:**
+- [ ] Ambiguous instruction
+- [ ] Missing context
+- [ ] Assumed knowledge
+- [ ] Faulty mental model
+- [ ] Other: ___
+
+**Preventive Guideline:** [What rule would prevent this?]
+
+**Consider Hook?** [ ] Yes - if this is a recurring pattern
+```
+
+### Step 4: Recovery
+Rewind to pre-error state using double-escape restore.
+
+## Key Principle
+Capture the EXACT prompt wording. Paraphrasing loses the specific language that caused the failure.</code></pre>
+                        </div>
+                    </div>
+
+                    <!-- Root Cause Categories -->
+                    <div class="p-4 bg-signalDim border border-signal/30">
+                        <h4 class="text-sm text-signal font-mono mb-3">ROOT_CAUSE_CATEGORIES</h4>
+                        <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Ambiguous instruction</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Missing context</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Assumed knowledge</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Faulty mental model</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Hallucination</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Context lost</span>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Divider -->
+                <div class="border-t border-white/10"></div>
+
+                <!-- /log_success Skill -->
+                <section id="log-success">
+                    <div class="flex items-center gap-3 mb-6">
+                        <div class="p-2 bg-acid/10 border border-acid/30">
+                            <i data-lucide="check-circle" class="w-6 h-6 text-acid"></i>
+                        </div>
+                        <div>
+                            <h2 class="font-display text-2xl text-white font-bold">/log_success</h2>
+                            <p class="text-sm text-gray-500">Capture what works for reuse</p>
+                        </div>
+                    </div>
+
+                    <!-- Purpose -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-acid font-mono mb-3">// PURPOSE</h3>
+                        <p class="text-gray-400 leading-relaxed">
+                            When Claude produces excellent results, capture the interaction pattern while context is fresh. Look for <strong class="text-white">recurring patterns that can be promoted</strong> to CLAUDE.md or converted into reusable skills.
+                        </p>
+                    </div>
+
+                    <!-- Workflow -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-ice font-mono mb-3">// WORKFLOW</h3>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-acid font-display font-bold">1</span>
+                                <p class="text-xs text-gray-400 mt-2">Pause to preserve context</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-acid font-display font-bold">2</span>
+                                <p class="text-xs text-gray-400 mt-2">Identify what worked</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-acid font-display font-bold">3</span>
+                                <p class="text-xs text-gray-400 mt-2">Record exact prompt</p>
+                            </div>
+                            <div class="p-3 bg-surface border border-white/5 text-center">
+                                <span class="text-2xl text-acid font-display font-bold">4</span>
+                                <p class="text-xs text-gray-400 mt-2">Extract reusable template</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Skill Definition -->
+                    <div class="mb-6">
+                        <h3 class="text-sm text-acid font-mono mb-3">// SKILL_DEFINITION</h3>
+                        <p class="text-xs text-gray-500 mb-2">Save as: <code class="text-acid">.claude/skills/log-success.md</code></p>
+                        <div class="code-block border border-white/10 bg-panel">
+                            <button class="copy-btn px-3 py-1 bg-acid/10 text-acid text-xs border border-acid/30 hover:bg-acid hover:text-black transition-colors" onclick="copyCode(this, 'log-success-code')">
+                                <i data-lucide="copy" class="w-3 h-3 inline"></i> Copy
+                            </button>
+                            <pre class="p-4 text-sm text-gray-300 overflow-x-auto" id="log-success-code"><code># /log_success
+
+Capture effective patterns for reuse.
+
+## Trigger
+Invoke when Claude produces excellent results that you want to replicate.
+
+## Workflow
+
+### Step 1: Pause
+Capture while context is fresh - don't wait until later.
+
+### Step 2: Identify Success Factors
+What made this work?
+- Clear, specific instruction?
+- Good examples provided?
+- Appropriate context given?
+- Right level of detail?
+
+### Step 3: Document the Success
+Create log entry:
+
+```markdown
+## Success Log: [YYYY-MM-DD-HHMM]
+
+**Context:** [What were you building?]
+
+**Outcome:** [What Claude produced that impressed you]
+
+**Exact Prompt (verbatim):**
+> [Copy the exact text you sent]
+
+**Success Factors:**
+- [ ] Clear, specific instruction
+- [ ] Effective example included
+- [ ] Appropriate context scope
+- [ ] Good constraint definition
+- [ ] Other: ___
+
+**What Made It Work:**
+1. [Factor 1]
+2. [Factor 2]
+3. [Factor 3]
+
+**Generalized Template:**
+> [Reusable version with placeholders]
+
+**Promote to CLAUDE.md?** [ ] Yes - if this is a recurring need
+**Convert to Skill?** [ ] Yes - if this is a complex workflow
+```
+
+### Step 4: Pattern Recognition
+Look across multiple success logs to identify recurring patterns worth promoting.
+
+## Key Principle
+Success patterns compound. What works once can work many times if documented properly.</code></pre>
+                        </div>
+                    </div>
+
+                    <!-- Success Factors -->
+                    <div class="p-4 bg-acidDim border border-acid/30">
+                        <h4 class="text-sm text-acid font-mono mb-3">SUCCESS_FACTORS_CHECKLIST</h4>
+                        <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Clear instruction</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Good examples</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Right context scope</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Defined constraints</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Specific output format</span>
+                            <span class="px-2 py-1 bg-panel border border-white/10 text-gray-400">Iterative refinement</span>
+                        </div>
+                    </div>
+                </section>
+
+            </div>
+
+            <!-- Directory Structure -->
+            <section class="mt-16 p-6 bg-surface border border-white/10">
+                <h3 class="text-sm text-ice font-mono mb-4">// RECOMMENDED_DIRECTORY_STRUCTURE</h3>
+                <pre class="text-sm text-gray-400 overflow-x-auto"><code>your-project/
+├── .claude/
+│   ├── skills/
+│   │   ├── log-error.md
+│   │   └── log-success.md
+│   ├── error-logs/
+│   │   ├── 2024-01-15-1430.md
+│   │   └── 2024-01-16-0900.md
+│   ├── success-logs/
+│   │   └── 2024-01-15-1600.md
+│   └── commands/
+│       └── [your custom commands]
+└── CLAUDE.md</code></pre>
+            </section>
+
+        </main>
+
+        <!-- Footer -->
+        <footer class="border-t border-white/10 bg-panel/50 mt-auto">
+            <div class="max-w-5xl mx-auto px-6 py-8">
+                <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                    <div class="text-center md:text-left">
+                        <p class="text-gray-500 font-mono text-sm">
+                            <span class="text-signal">//</span> Log errors. Log successes. <span class="text-acid">Build the feedback loops.</span>
+                        </p>
+                    </div>
+                    <div class="flex items-center gap-6 text-xs font-mono">
+                        <a href="index.html" class="text-gray-500 hover:text-acid transition-colors flex items-center gap-2">
+                            <i data-lucide="arrow-left" class="w-3 h-3"></i>
+                            PATTERNS_HUB
+                        </a>
+                        <a href="lessons.html" class="text-gray-500 hover:text-ice transition-colors flex items-center gap-2">
+                            <i data-lucide="graduation-cap" class="w-3 h-3"></i>
+                            LESSONS
+                        </a>
+                        <a href="quick-reference.html" class="text-gray-500 hover:text-signal transition-colors flex items-center gap-2">
+                            <i data-lucide="table" class="w-3 h-3"></i>
+                            QUICK_REF
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+    </div>
+
+    <script>
+        // Initialize Lucide icons
+        lucide.createIcons();
+
+        // Copy code functionality
+        function copyCode(button, codeId) {
+            const codeElement = document.getElementById(codeId);
+            const text = codeElement.textContent;
+
+            navigator.clipboard.writeText(text).then(() => {
+                button.innerHTML = '<i data-lucide="check" class="w-3 h-3 inline"></i> Copied!';
+                button.classList.add('copied');
+                lucide.createIcons();
+
+                setTimeout(() => {
+                    button.innerHTML = '<i data-lucide="copy" class="w-3 h-3 inline"></i> Copy';
+                    button.classList.remove('copied');
+                    lucide.createIcons();
+                }, 2000);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -241,6 +241,24 @@
                         </div>
                     </a>
 
+                    <!-- Card 9 - Code Patterns -->
+                    <a href="code-patterns/index.html" class="group block border border-white/10 bg-panel hover:border-signal transition-all duration-300 relative overflow-hidden">
+                        <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-signal">
+                            <i data-lucide="git-branch" class="w-6 h-6"></i>
+                        </div>
+                        <div class="p-6">
+                            <div class="text-xs text-signal font-mono mb-3">:: ADVANCED</div>
+                            <h4 class="font-display text-xl text-white font-bold mb-3 group-hover:text-signal transition-colors">Code patterns</h4>
+                            <p class="text-sm text-gray-500 font-mono leading-relaxed">
+                                Seven battle-tested Claude Code patterns. Error logging, commands-as-apps, hooks, context hygiene, and more.
+                            </p>
+                        </div>
+                        <div class="bg-surface px-6 py-2 border-t border-white/10 flex justify-between items-center text-xs font-mono text-gray-600 group-hover:text-signal transition-colors">
+                            <span>LOAD_PATTERNS</span>
+                            <span>-></span>
+                        </div>
+                    </a>
+
                 </div>
             </section>
 
@@ -294,9 +312,12 @@
                     </div>
                 </div>
 
-                <div class="mt-6 flex gap-4 relative z-10">
+                <div class="mt-6 flex flex-wrap gap-4 relative z-10">
                     <a href="downloads/CLAUDE-CODE-QUICKREF.md" download class="px-6 py-2 bg-ice text-black font-bold text-xs clip-notch hover:bg-white transition-colors flex items-center gap-2">
                         <i data-lucide="download" class="w-4 h-4"></i> DOWNLOAD_QUICKREF
+                    </a>
+                    <a href="code-patterns/index.html" class="px-6 py-2 border border-signal/30 text-signal font-bold text-xs hover:border-signal transition-colors flex items-center gap-2">
+                        <i data-lucide="git-branch" class="w-4 h-4"></i> ADVANCED_PATTERNS
                     </a>
                     <a href="llm-advisor/index.html" class="px-6 py-2 border border-ice/30 text-ice font-bold text-xs hover:border-ice transition-colors flex items-center gap-2">
                         <i data-lucide="compass" class="w-4 h-4"></i> EXPLORE_TOOLS_TRACK

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -1462,7 +1462,7 @@ node --version  <span class="text-gray-500"># Should show v20.x.x</span></code><
         <!-- Footer -->
         <footer class="border-t border-white/10 bg-void py-8">
             <div class="max-w-6xl mx-auto px-6 text-center text-xs font-mono text-gray-600">
-                <p>SYSTEM STATUS: ONLINE // <a href="../index.html" class="hover:text-acid transition-colors">RETURN_ROOT</a> // <a href="../vibe-coding/index.html" class="hover:text-acid transition-colors">VIBE_GUIDE</a></p>
+                <p>SYSTEM STATUS: ONLINE // <a href="../index.html" class="hover:text-acid transition-colors">RETURN_ROOT</a> // <a href="../vibe-coding/index.html" class="hover:text-acid transition-colors">VIBE_GUIDE</a> // <a href="../code-patterns/index.html" class="hover:text-signal transition-colors">CODE_PATTERNS</a></p>
                 <p class="mt-2">AMDITIS_KIT v2.6 // Part of the CCM Resource Collection</p>
                 <p class="mt-2 text-gray-700">Status line setup based on <a href="https://www.aihero.dev/creating-the-perfect-claude-code-status-line" class="text-gray-600 hover:text-acid transition-colors" target="_blank" rel="noopener">Matt Pocock's guide</a></p>
             </div>


### PR DESCRIPTION
Integrate content from jamditis/stash claude-code-patterns folder into the resource kit website. New section includes:

- Main hub page with overview and navigation (code-patterns/index.html)
- Seven lessons page with accordion UI covering error logging, commands as apps, hooks for safety, context hygiene, subagent control, lean tool stacks, and prompt engineering (lessons.html)
- Quick reference page with situation-action lookup tables for debugging, workflows, permissions, recovery, and optimization (quick-reference.html)
- Executable skills page with /log_error and /log_success command templates ready to copy into .claude/skills/ (skills.html)

Cross-links added to main hub, vibe-coding footer, and terminal-setup footer. Code patterns card added to GUIDES section on main index.