### PR TITLE
Replace favicon.ico with SVG favicon across documentation

### DIFF
--- a/resource-kit/docs/html-editor/index.html
+++ b/resource-kit/docs/html-editor/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HTML EDITOR // AMDITIS</title>
+    <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/resource-kit/docs/llm-advisor/vibe-coding/favicon.svg
+++ b/resource-kit/docs/llm-advisor/vibe-coding/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0a0a0c"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="bold" font-size="22" fill="#00dc82">A</text>
+</svg>

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -7,8 +7,7 @@
     <meta name="description" content="A practical guide for journalists and non-developers by Joe Amditis.">
     
     <!-- Favicon -->
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 
     <!-- Open Graph / Social Media Meta Tags -->
     <meta property="og:title" content="Vibe coding starter guide for newsrooms">

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="A practical guide for journalists and non-developers by Joe Amditis.">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
     <!-- Open Graph / Social Media Meta Tags -->
     <meta property="og:title" content="Vibe coding starter guide for newsrooms">


### PR DESCRIPTION
## Summary
Updated favicon implementation across documentation sites by replacing the legacy `.ico` format with a modern SVG favicon, improving scalability and reducing file size.

## Key Changes
- **Created new SVG favicon** (`resource-kit/docs/llm-advisor/vibe-coding/favicon.svg`): A dark-themed icon with a bold green "A" letter on a rounded square background
- **Updated vibe-coding documentation**: Replaced two separate `.ico` favicon links with a single SVG favicon reference
- **Updated HTML editor**: Added SVG favicon link to the HTML editor documentation page

## Implementation Details
- The new SVG favicon uses a dark background (`#0a0a0c`) with a vibrant green accent color (`#00dc82`) for the letter "A"
- SVG format provides better scalability across different device sizes and resolutions compared to the previous `.ico` format
- Consolidated favicon references from two separate links to a single, cleaner link tag with `type="image/svg+xml"`

https://claude.ai/code/session_013XLFDTt8Ntj2SqgXwZ8BLy