### PR TITLE
Remove animate-drift animation from glossary page

### DIFF
--- a/resource-kit/docs/vibe-coding/glossary/glossary-bounce.test.sh
+++ b/resource-kit/docs/vibe-coding/glossary/glossary-bounce.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Test: Glossary page should not have continuous bounce/drift animations
+# Bug: The animate-drift class on a large background div causes the entire
+# glossary to visually bounce up and down in a 25-second infinite loop.
+
+set -euo pipefail
+
+GLOSSARY_HTML="$(dirname "$0")/index.html"
+EXIT_CODE=0
+
+echo "=== Glossary Bounce Bug Test ==="
+
+# Test 1: No animate-drift class on any element in the glossary page
+if grep -q 'animate-drift' "$GLOSSARY_HTML"; then
+    echo "FAIL: Found 'animate-drift' class in glossary page."
+    echo "      This causes the page to visually bounce due to a large"
+    echo "      background element continuously animating its position."
+    EXIT_CODE=1
+else
+    echo "PASS: No animate-drift animation found in glossary page."
+fi
+
+exit $EXIT_CODE

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -51,7 +51,7 @@
 <body class="antialiased font-sans bg-canvas text-ink">
 
     <div class="paper-overlay"></div>
-    <div class="fixed top-[-15%] left-[-10%] w-[50%] h-[50%] bg-accent/5 rounded-full blur-[140px] animate-drift pointer-events-none z-0"></div>
+    <div class="fixed top-[-15%] left-[-10%] w-[50%] h-[50%] bg-accent/5 rounded-full blur-[140px] pointer-events-none z-0"></div>
 
     <div class="relative z-10 flex min-h-screen flex-col">
 


### PR DESCRIPTION
## Summary
Removes the `animate-drift` CSS class from the glossary page's background decoration element to eliminate unwanted continuous bounce/drift animations that were causing visual distraction.

## Changes
- **Removed `animate-drift` class** from the fixed background div in `glossary/index.html` that was causing the entire glossary page to visually bounce in a 25-second infinite loop
- **Added test file** `glossary-bounce.test.sh` to verify the `animate-drift` class is not present on the glossary page and prevent regression

## Details
The `animate-drift` class was applied to a large fixed-position background element (a blurred accent-colored circle positioned off-screen). This caused the entire glossary page to continuously animate its position, creating a distracting bouncing effect. The element still provides the intended visual design through its color, blur, and positioning—only the animation has been removed.

https://claude.ai/code/session_014XpSnqAK7K2W7jSeUvPqHw