### PR TITLE
Add beginner mode toggle to frontend glossary

### DIFF
--- a/resource-kit/docs/vibe-coding/glossary-frontend/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/term.html
@@ -29,6 +29,39 @@
         }
         .related-card:hover .related-name { color: var(--accent); }
 
+        /* Beginner mode */
+        .beginner-toggle-track {
+            transition: background 0.2s ease;
+        }
+        .beginner-toggle-thumb {
+            transition: transform 0.2s ease;
+        }
+        body.beginner-mode .beginner-toggle-track {
+            background: var(--accent);
+        }
+        body.beginner-mode .beginner-toggle-thumb {
+            transform: translateX(20px);
+        }
+
+        /* In beginner mode: show analogy first, hide tradeoffs */
+        body.beginner-mode main {
+            display: flex;
+            flex-direction: column;
+        }
+        body.beginner-mode #analogy-section   { order: -1; }
+        body.beginner-mode #definition-section { order: 0; }
+        body.beginner-mode #examples-section  { order: 1; }
+        body.beginner-mode #usecases-section  { order: 2; }
+        body.beginner-mode #tradeoffs-section { display: none !important; }
+        body.beginner-mode #related-section   { order: 3; }
+        body.beginner-mode .term-nav-row       { order: 4; }
+
+        /* Analogy card gets accent border in beginner mode */
+        body.beginner-mode #analogy-section .deckle-card {
+            border: 1px solid rgba(61,75,64,0.35);
+            box-shadow: 0 0 0 3px rgba(61,75,64,0.07);
+        }
+
         #progress-bar {
             position: fixed;
             top: 0; left: 0;
@@ -62,9 +95,19 @@
                     <span id="breadcrumb-term" class="text-ink font-medium truncate max-w-[180px]"></span>
                 </div>
             </div>
-            <a href="/vibe-coding/glossary-frontend/" class="flex items-center gap-2 px-3 py-1 border border-ink/20 text-xs text-ink/60 hover:border-accent hover:text-accent transition-colors rounded">
-                <i data-lucide="arrow-left" class="w-3 h-3"></i> All terms
-            </a>
+            <div class="flex items-center gap-3">
+                <!-- Beginner mode toggle -->
+                <button id="beginner-toggle" aria-pressed="false" class="flex items-center gap-2 px-3 py-1.5 border border-ink/20 rounded text-xs text-ink/60 hover:border-accent hover:text-accent transition-colors select-none">
+                    <i data-lucide="lightbulb" class="w-3 h-3"></i>
+                    <span class="hidden sm:inline">Beginner mode</span>
+                    <div class="beginner-toggle-track relative w-8 h-4 bg-ink/20 rounded-full ml-1">
+                        <div class="beginner-toggle-thumb absolute top-0.5 left-0.5 w-3 h-3 bg-white rounded-full shadow-sm"></div>
+                    </div>
+                </button>
+                <a href="/vibe-coding/glossary-frontend/" class="flex items-center gap-2 px-3 py-1 border border-ink/20 text-xs text-ink/60 hover:border-accent hover:text-accent transition-colors rounded">
+                    <i data-lucide="arrow-left" class="w-3 h-3"></i> All terms
+                </a>
+            </div>
         </div>
     </header>
 
@@ -100,7 +143,7 @@
         <main class="max-w-4xl mx-auto px-6 py-12 space-y-14">
 
             <!-- Definition -->
-            <section class="reveal-section">
+            <section id="definition-section" class="reveal-section">
                 <h2 class="prose-section font-display text-2xl font-light italic text-ink mb-5 pb-3 border-b border-ink/10">Definition</h2>
                 <div id="definition-text" class="text-ink/80 leading-relaxed space-y-4 text-[0.97rem]"></div>
             </section>
@@ -152,7 +195,7 @@
             </section>
 
             <!-- Nav -->
-            <div class="pt-6 border-t border-ink/10 flex items-center justify-between">
+            <div class="term-nav-row pt-6 border-t border-ink/10 flex items-center justify-between">
                 <a id="prev-link" href="#" class="hidden group flex items-center gap-2 text-sm text-ink/50 hover:text-accent transition-colors">
                     <i data-lucide="arrow-left" class="w-4 h-4 group-hover:-translate-x-1 transition-transform"></i>
                     <span id="prev-label"></span>
@@ -317,6 +360,25 @@
         const docHeight = document.documentElement.scrollHeight - window.innerHeight;
         bar.style.width = `${(scrollTop / docHeight) * 100}%`;
     }, { passive: true });
+
+    // Beginner mode toggle — persisted in localStorage
+    const toggleBtn = document.getElementById('beginner-toggle');
+    const STORAGE_KEY = 'glossary-beginner-mode';
+
+    function applyBeginnerMode(enabled) {
+        document.body.classList.toggle('beginner-mode', enabled);
+        toggleBtn.setAttribute('aria-pressed', String(enabled));
+        localStorage.setItem(STORAGE_KEY, enabled ? '1' : '0');
+    }
+
+    toggleBtn.addEventListener('click', () => {
+        applyBeginnerMode(!document.body.classList.contains('beginner-mode'));
+    });
+
+    // Restore saved preference
+    if (localStorage.getItem(STORAGE_KEY) === '1') {
+        applyBeginnerMode(true);
+    }
 
     const observer = new IntersectionObserver((entries) => {
         entries.forEach(e => {


### PR DESCRIPTION
## Summary

- Adds a **Beginner mode** toggle button to the `term.html` header, next to the existing "All terms" link
- In beginner mode, the real-world analogy floats to the top of the page (via CSS `order`), the tradeoffs section is hidden, and the analogy card gets a subtle accent border
- Preference persists across term navigation via `localStorage` — toggling once applies to all subsequent term pages
- Toggle label is hidden on mobile (icon only) to save header space

## How it works

Uses a CSS class toggle on `body.beginner-mode` rather than JS DOM reordering. This keeps the `IntersectionObserver` scroll animations working correctly since element references don't change — only their visual order does.

## Test plan

- [ ] Toggle on a term page — analogy should move to top, tradeoffs disappear
- [ ] Navigate to a related term — beginner mode should still be active
- [ ] Refresh the page — preference should be restored from localStorage
- [ ] Toggle off — page returns to standard order with tradeoffs visible
- [ ] Check on mobile — icon-only button, no label overflow