### PR TITLE
Add ask-ai dropdown to all pages

### DIFF
--- a/resource-kit/docs/about/index.html
+++ b/resource-kit/docs/about/index.html
@@ -13,6 +13,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/assets/ask-ai.js
+++ b/resource-kit/docs/assets/ask-ai.js
@@ -1,0 +1,387 @@
+/**
+ * @fileoverview Ask AI dropdown component (cream theme)
+ *
+ * Self-contained vanilla JS component that injects an "Ask an AI about this"
+ * dropdown button into every page. Provides quick links to Claude, ChatGPT,
+ * and Gemini with a page-aware prompt, plus a markdown download option using
+ * Turndown.js.
+ *
+ * Usage: Include this script on any page. It auto-initializes on
+ * DOMContentLoaded and injects itself after the last <header> element.
+ *
+ * All styles are inline. No external CSS required.
+ *
+ * @module AskAI
+ */
+
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------------
+  // THEME CONSTANTS
+  // ---------------------------------------------------------------------------
+
+  var THEME = {
+    buttonBg: '#3d4b40',
+    buttonColor: '#ffffff',
+    buttonBorder: '1px solid #3d4b40',
+    buttonRadius: '0.5rem',
+    panelBg: '#ffffff',
+    panelColor: '#121212',
+    panelBorder: '1px solid #d6cdb7',
+    panelRadius: '0.75rem',
+    panelShadow: '0 10px 25px rgba(0,0,0,0.1)',
+    itemHoverBg: '#f5f0e6',
+    iconColor: '#3d4b40',
+    fontFamily: "'Plus Jakarta Sans', sans-serif"
+  };
+
+  // ---------------------------------------------------------------------------
+  // SVG ICONS (hardcoded static markup -- no user input, safe for innerHTML)
+  // ---------------------------------------------------------------------------
+
+  var ICONS = {
+    sparkle: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z"/></svg>',
+    chatBubble: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+    diamond: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L22 12L12 22L2 12Z"/></svg>',
+    download: '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>',
+    chevronDown: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>'
+  };
+
+  // ---------------------------------------------------------------------------
+  // HELPERS
+  // ---------------------------------------------------------------------------
+
+  function getPageTitle() {
+    var h1 = document.querySelector('h1');
+    return (h1 && h1.textContent.trim()) || document.title || 'this page';
+  }
+
+  function getPrompt() {
+    var title = getPageTitle();
+    var hostname = window.location.hostname;
+    var url = window.location.href;
+    return 'I\'m reading about "' + title + '" on ' + hostname + '.\n\nURL: ' + url + '\n\nCan you explain the key concepts and help me apply them?';
+  }
+
+  function getSlug() {
+    var path = window.location.pathname.replace(/\/$/, '').replace(/^\//, '');
+    if (!path) return 'page';
+    return path.replace(/\//g, '-').replace(/\.html?$/, '') || 'page';
+  }
+
+  function setStyle(el, styles) {
+    for (var key in styles) {
+      if (styles.hasOwnProperty(key)) {
+        el.style[key] = styles[key];
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // TURNDOWN LOADER + MARKDOWN DOWNLOAD
+  // ---------------------------------------------------------------------------
+
+  var turndownLoaded = false;
+
+  function loadTurndown(callback) {
+    if (turndownLoaded && typeof TurndownService !== 'undefined') {
+      callback();
+      return;
+    }
+    var script = document.createElement('script');
+    script.src = 'https://unpkg.com/turndown/dist/turndown.js';
+    script.onload = function () {
+      turndownLoaded = true;
+      callback();
+    };
+    script.onerror = function () {
+      alert('Failed to load markdown converter. Please try again.');
+    };
+    document.head.appendChild(script);
+  }
+
+  function downloadMarkdown() {
+    loadTurndown(function () {
+      var mainEl = document.querySelector('main');
+      var html = mainEl ? mainEl.innerHTML : document.body.innerHTML;
+      var td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
+      var md = td.turndown(html);
+      var title = getPageTitle();
+      var url = window.location.href;
+      var content = '# ' + title + '\n\nSource: ' + url + '\n\n' + md;
+      var blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = getSlug() + '.md';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // DROPDOWN ITEMS CONFIG
+  // ---------------------------------------------------------------------------
+
+  var ITEMS = [
+    {
+      label: 'Ask Claude',
+      icon: ICONS.sparkle,
+      action: function () {
+        window.open('https://claude.ai/new?q=' + encodeURIComponent(getPrompt()), '_blank');
+      }
+    },
+    {
+      label: 'Ask ChatGPT',
+      icon: ICONS.chatBubble,
+      action: function () {
+        window.open('https://chatgpt.com/?q=' + encodeURIComponent(getPrompt()), '_blank');
+      }
+    },
+    {
+      label: 'Ask Gemini',
+      icon: ICONS.diamond,
+      action: function () {
+        window.open('https://gemini.google.com/app?q=' + encodeURIComponent(getPrompt()), '_blank');
+      }
+    },
+    {
+      label: 'Download as markdown',
+      icon: ICONS.download,
+      action: downloadMarkdown
+    }
+  ];
+
+  // ---------------------------------------------------------------------------
+  // DOM CONSTRUCTION HELPERS
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates an SVG element container from a static SVG string.
+   * The SVG strings in ICONS are hardcoded constants (no user input),
+   * so this is safe from injection.
+   */
+  function createIconSpan(svgString) {
+    var span = document.createElement('span');
+    setStyle(span, {
+      color: THEME.iconColor,
+      display: 'inline-flex',
+      flexShrink: '0'
+    });
+    // SVG strings are static constants defined above, not user input
+    span.innerHTML = svgString;
+    return span;
+  }
+
+  // ---------------------------------------------------------------------------
+  // BUILD DOM
+  // ---------------------------------------------------------------------------
+
+  function init() {
+    // Find the last <header> on the page
+    var headers = document.querySelectorAll('header');
+    if (!headers.length) return;
+    var lastHeader = headers[headers.length - 1];
+
+    // Outer wrapper (max-width container with auto margins)
+    var wrapper = document.createElement('div');
+    setStyle(wrapper, {
+      maxWidth: '64rem',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      paddingLeft: '1.5rem',
+      paddingRight: '1.5rem',
+      paddingTop: '0.75rem',
+      paddingBottom: '0',
+      position: 'relative',
+      zIndex: '40',
+      fontFamily: THEME.fontFamily
+    });
+
+    // Container for the button + dropdown (inline-block so it sizes to content)
+    var container = document.createElement('div');
+    setStyle(container, {
+      position: 'relative',
+      display: 'inline-block'
+    });
+
+    // Trigger button
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-haspopup', 'true');
+
+    var buttonLabel = document.createTextNode('Ask an AI about this ');
+    button.appendChild(buttonLabel);
+    // Chevron icon (static SVG constant)
+    var chevronSpan = document.createElement('span');
+    chevronSpan.style.display = 'inline-flex';
+    chevronSpan.innerHTML = ICONS.chevronDown;
+    button.appendChild(chevronSpan);
+
+    setStyle(button, {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+      background: THEME.buttonBg,
+      color: THEME.buttonColor,
+      border: THEME.buttonBorder,
+      borderRadius: THEME.buttonRadius,
+      padding: '0.5rem 1rem',
+      fontSize: '0.8125rem',
+      fontWeight: '600',
+      fontFamily: THEME.fontFamily,
+      cursor: 'pointer',
+      lineHeight: '1.4',
+      whiteSpace: 'nowrap',
+      transition: 'opacity 0.15s ease'
+    });
+
+    button.addEventListener('mouseenter', function () { button.style.opacity = '0.85'; });
+    button.addEventListener('mouseleave', function () { button.style.opacity = '1'; });
+
+    // Dropdown panel
+    var panel = document.createElement('div');
+    panel.setAttribute('role', 'menu');
+    setStyle(panel, {
+      position: 'absolute',
+      top: 'calc(100% + 0.375rem)',
+      left: '0',
+      minWidth: '13rem',
+      background: THEME.panelBg,
+      color: THEME.panelColor,
+      border: THEME.panelBorder,
+      borderRadius: THEME.panelRadius,
+      boxShadow: THEME.panelShadow,
+      padding: '0.375rem',
+      display: 'none',
+      zIndex: '50',
+      fontFamily: THEME.fontFamily
+    });
+
+    // Build menu items
+    ITEMS.forEach(function (item) {
+      var menuItem = document.createElement('button');
+      menuItem.type = 'button';
+      menuItem.setAttribute('role', 'menuitem');
+
+      // Icon
+      menuItem.appendChild(createIconSpan(item.icon));
+
+      // Label text (safe -- uses textContent)
+      var labelSpan = document.createElement('span');
+      labelSpan.textContent = item.label;
+      menuItem.appendChild(labelSpan);
+
+      setStyle(menuItem, {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.625rem',
+        width: '100%',
+        padding: '0.5rem 0.625rem',
+        fontSize: '0.8125rem',
+        fontWeight: '500',
+        fontFamily: THEME.fontFamily,
+        color: THEME.panelColor,
+        background: 'transparent',
+        border: 'none',
+        borderRadius: '0.5rem',
+        cursor: 'pointer',
+        textAlign: 'left',
+        lineHeight: '1.4',
+        whiteSpace: 'nowrap',
+        transition: 'background 0.12s ease'
+      });
+
+      menuItem.addEventListener('mouseenter', function () {
+        menuItem.style.background = THEME.itemHoverBg;
+      });
+      menuItem.addEventListener('mouseleave', function () {
+        menuItem.style.background = 'transparent';
+      });
+
+      menuItem.addEventListener('click', function () {
+        closeDropdown();
+        item.action();
+      });
+
+      panel.appendChild(menuItem);
+    });
+
+    container.appendChild(button);
+    container.appendChild(panel);
+    wrapper.appendChild(container);
+
+    // Inject after the last header
+    if (lastHeader.nextSibling) {
+      lastHeader.parentNode.insertBefore(wrapper, lastHeader.nextSibling);
+    } else {
+      lastHeader.parentNode.appendChild(wrapper);
+    }
+
+    // -----------------------------------------------------------------------
+    // INTERACTION LOGIC
+    // -----------------------------------------------------------------------
+
+    var isOpen = false;
+
+    function openDropdown() {
+      isOpen = true;
+      panel.style.display = 'block';
+      button.setAttribute('aria-expanded', 'true');
+      // Reposition if it overflows the right edge of the viewport
+      requestAnimationFrame(function () {
+        var rect = panel.getBoundingClientRect();
+        if (rect.right > window.innerWidth - 8) {
+          panel.style.left = 'auto';
+          panel.style.right = '0';
+        }
+      });
+    }
+
+    function closeDropdown() {
+      isOpen = false;
+      panel.style.display = 'none';
+      button.setAttribute('aria-expanded', 'false');
+      // Reset positioning for next open
+      panel.style.left = '0';
+      panel.style.right = 'auto';
+    }
+
+    button.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (isOpen) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    });
+
+    // Click outside closes dropdown
+    document.addEventListener('click', function (e) {
+      if (isOpen && !container.contains(e.target)) {
+        closeDropdown();
+      }
+    });
+
+    // Escape closes dropdown
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && isOpen) {
+        closeDropdown();
+        button.focus();
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // AUTO-INITIALIZATION
+  // ---------------------------------------------------------------------------
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/resource-kit/docs/assets/ask-ai.js
+++ b/resource-kit/docs/assets/ask-ai.js
@@ -7,7 +7,8 @@
  * Turndown.js.
  *
  * Usage: Include this script on any page. It auto-initializes on
- * DOMContentLoaded and injects itself after the last <header> element.
+ * DOMContentLoaded and injects itself after the last <header> element,
+ * or as the first child of <main> if no <header> is found.
  *
  * All styles are inline. No external CSS required.
  *
@@ -82,23 +83,28 @@
   // TURNDOWN LOADER + MARKDOWN DOWNLOAD
   // ---------------------------------------------------------------------------
 
-  var turndownLoaded = false;
+  var turndownPromise = null;
 
   function loadTurndown(callback) {
-    if (turndownLoaded && typeof TurndownService !== 'undefined') {
+    if (typeof TurndownService !== 'undefined') {
       callback();
       return;
     }
-    var script = document.createElement('script');
-    script.src = 'https://unpkg.com/turndown/dist/turndown.js';
-    script.onload = function () {
-      turndownLoaded = true;
-      callback();
-    };
-    script.onerror = function () {
+    if (!turndownPromise) {
+      turndownPromise = new Promise(function (resolve, reject) {
+        var script = document.createElement('script');
+        script.src = 'https://unpkg.com/turndown@7.2.0/dist/turndown.js';
+        script.onload = resolve;
+        script.onerror = function () {
+          turndownPromise = null; // allow retry on failure
+          reject(new Error('Failed to load Turndown'));
+        };
+        document.head.appendChild(script);
+      });
+    }
+    turndownPromise.then(callback).catch(function () {
       alert('Failed to load markdown converter. Please try again.');
-    };
-    document.head.appendChild(script);
+    });
   }
 
   function downloadMarkdown() {
@@ -129,22 +135,22 @@
     {
       label: 'Ask Claude',
       icon: ICONS.sparkle,
-      action: function () {
-        window.open('https://claude.ai/new?q=' + encodeURIComponent(getPrompt()), '_blank');
+      href: function () {
+        return 'https://claude.ai/new?q=' + encodeURIComponent(getPrompt());
       }
     },
     {
       label: 'Ask ChatGPT',
       icon: ICONS.chatBubble,
-      action: function () {
-        window.open('https://chatgpt.com/?q=' + encodeURIComponent(getPrompt()), '_blank');
+      href: function () {
+        return 'https://chatgpt.com/?q=' + encodeURIComponent(getPrompt());
       }
     },
     {
       label: 'Ask Gemini',
       icon: ICONS.diamond,
-      action: function () {
-        window.open('https://gemini.google.com/app?q=' + encodeURIComponent(getPrompt()), '_blank');
+      href: function () {
+        return 'https://gemini.google.com/app?q=' + encodeURIComponent(getPrompt());
       }
     },
     {
@@ -180,10 +186,11 @@
   // ---------------------------------------------------------------------------
 
   function init() {
-    // Find the last <header> on the page
+    // Find injection point: after last <header>, or first child of <main>
     var headers = document.querySelectorAll('header');
-    if (!headers.length) return;
-    var lastHeader = headers[headers.length - 1];
+    var lastHeader = headers.length ? headers[headers.length - 1] : null;
+    var mainEl = document.querySelector('main');
+    if (!lastHeader && !mainEl) return;
 
     // Outer wrapper (max-width container with auto margins)
     var wrapper = document.createElement('div');
@@ -211,7 +218,7 @@
     var button = document.createElement('button');
     button.type = 'button';
     button.setAttribute('aria-expanded', 'false');
-    button.setAttribute('aria-haspopup', 'true');
+    button.setAttribute('aria-haspopup', 'dialog');
 
     var buttonLabel = document.createTextNode('Ask an AI about this ');
     button.appendChild(buttonLabel);
@@ -244,7 +251,8 @@
 
     // Dropdown panel
     var panel = document.createElement('div');
-    panel.setAttribute('role', 'menu');
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', 'Ask an AI about this page');
     setStyle(panel, {
       position: 'absolute',
       top: 'calc(100% + 0.375rem)',
@@ -263,9 +271,28 @@
 
     // Build menu items
     ITEMS.forEach(function (item) {
-      var menuItem = document.createElement('button');
-      menuItem.type = 'button';
-      menuItem.setAttribute('role', 'menuitem');
+      var menuItem;
+
+      if (item.href) {
+        // AI link items use <a> with noopener noreferrer for tabnabbing protection
+        menuItem = document.createElement('a');
+        menuItem.href = item.href();
+        menuItem.target = '_blank';
+        menuItem.rel = 'noopener noreferrer';
+        menuItem.addEventListener('click', function () {
+          // Update href with current page context right before navigation
+          menuItem.href = item.href();
+          closeDropdown();
+        });
+      } else {
+        // Non-link items (e.g. download) use <button>
+        menuItem = document.createElement('button');
+        menuItem.type = 'button';
+        menuItem.addEventListener('click', function () {
+          closeDropdown();
+          item.action();
+        });
+      }
 
       // Icon
       menuItem.appendChild(createIconSpan(item.icon));
@@ -292,6 +319,7 @@
         textAlign: 'left',
         lineHeight: '1.4',
         whiteSpace: 'nowrap',
+        textDecoration: 'none',
         transition: 'background 0.12s ease'
       });
 
@@ -302,11 +330,6 @@
         menuItem.style.background = 'transparent';
       });
 
-      menuItem.addEventListener('click', function () {
-        closeDropdown();
-        item.action();
-      });
-
       panel.appendChild(menuItem);
     });
 
@@ -314,11 +337,15 @@
     container.appendChild(panel);
     wrapper.appendChild(container);
 
-    // Inject after the last header
-    if (lastHeader.nextSibling) {
-      lastHeader.parentNode.insertBefore(wrapper, lastHeader.nextSibling);
+    // Inject after the last header, or as first child of <main>
+    if (lastHeader) {
+      if (lastHeader.nextSibling) {
+        lastHeader.parentNode.insertBefore(wrapper, lastHeader.nextSibling);
+      } else {
+        lastHeader.parentNode.appendChild(wrapper);
+      }
     } else {
-      lastHeader.parentNode.appendChild(wrapper);
+      mainEl.insertBefore(wrapper, mainEl.firstChild);
     }
 
     // -----------------------------------------------------------------------

--- a/resource-kit/docs/code-patterns/index.html
+++ b/resource-kit/docs/code-patterns/index.html
@@ -84,6 +84,7 @@
             animation: drift 25s ease-in-out infinite;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/code-patterns/lessons/index.html
+++ b/resource-kit/docs/code-patterns/lessons/index.html
@@ -80,6 +80,7 @@
             font-style: italic;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/code-patterns/quick-reference/index.html
+++ b/resource-kit/docs/code-patterns/quick-reference/index.html
@@ -91,6 +91,7 @@
             .ref-table td { border-color: #ccc; }
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/code-patterns/skills/index.html
+++ b/resource-kit/docs/code-patterns/skills/index.html
@@ -70,6 +70,7 @@
             opacity: 1;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/glossary/index.html
+++ b/resource-kit/docs/glossary/index.html
@@ -13,6 +13,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/html-editor/index.html
+++ b/resource-kit/docs/html-editor/index.html
@@ -127,6 +127,7 @@
             border-bottom: 1px solid rgba(18, 18, 18, 0.05);
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="font-sans overflow-x-hidden min-h-screen flex flex-col">
 

--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -14,6 +14,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/language-guide/index.html
+++ b/resource-kit/docs/language-guide/index.html
@@ -13,6 +13,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/llm-advisor-doc/index.html
+++ b/resource-kit/docs/llm-advisor-doc/index.html
@@ -52,6 +52,7 @@
             animation: drift 25s ease-in-out infinite;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/llm-advisor/ai-showcase/index.html
+++ b/resource-kit/docs/llm-advisor/ai-showcase/index.html
@@ -14,6 +14,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-mono bg-void text-chrome">
 

--- a/resource-kit/docs/llm-advisor/index.html
+++ b/resource-kit/docs/llm-advisor/index.html
@@ -24,6 +24,7 @@
             transform: translateX(4px);
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink h-full overflow-hidden">
 

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -144,6 +144,7 @@
             color: #000;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased min-h-screen flex flex-col md:flex-row relative selection:bg-accent-green selection:text-black">
 

--- a/resource-kit/docs/quick-reference-card/index.html
+++ b/resource-kit/docs/quick-reference-card/index.html
@@ -37,6 +37,7 @@
             .p-6 { padding: 1rem !important; }
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/style-guide/index.html
+++ b/resource-kit/docs/style-guide/index.html
@@ -13,6 +13,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -107,6 +107,7 @@
             animation: status-pulse 2s ease-in-out infinite;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/tool-stacks/index.html
+++ b/resource-kit/docs/tool-stacks/index.html
@@ -72,6 +72,7 @@
             border: 1px solid rgba(184, 134, 11, 0.3);
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/cheat-sheet/index.html
+++ b/resource-kit/docs/vibe-coding/cheat-sheet/index.html
@@ -45,6 +45,7 @@
             .pt-4 { padding-top: 0.5rem !important; }
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/common-mistakes/index.html
+++ b/resource-kit/docs/vibe-coding/common-mistakes/index.html
@@ -36,6 +36,7 @@
             50% { opacity: 0.5; }
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/essentials/index.html
+++ b/resource-kit/docs/vibe-coding/essentials/index.html
@@ -62,6 +62,7 @@
             font-variant-numeric: tabular-nums;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -47,6 +47,7 @@
             pointer-events: auto;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/index.html
+++ b/resource-kit/docs/vibe-coding/index.html
@@ -49,6 +49,7 @@
             animation: pulse-glow 2s ease-in-out infinite;
         }
     </style>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 

--- a/resource-kit/docs/vibe-coding/level-up/index.html
+++ b/resource-kit/docs/vibe-coding/level-up/index.html
@@ -13,6 +13,7 @@
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
+<script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">
 


### PR DESCRIPTION
## Summary
- Adds a self-contained "Ask an AI about this" dropdown button to all 23 tool pages
- Dropdown options: Ask Claude (default), Ask ChatGPT, Ask Gemini, Download as markdown
- Button injects inline after the page header with page-aware prompt pre-filled
- Turndown.js loaded on demand for markdown conversion
- Cream theme matching Amditis V2 design, fully accessible (ARIA, keyboard)

## Test plan
- [ ] Open any tool page — button appears below header
- [ ] Click button — dropdown shows 4 options in correct order (Claude first)
- [ ] Click "Ask Claude" — opens claude.ai/new with pre-filled prompt
- [ ] Click "Download as markdown" — downloads .md file with page content
- [ ] Resize to mobile — dropdown doesn't overflow viewport
- [ ] Press Escape — dropdown closes