### PR TITLE
Add SocialSnag card to My tools section

### DIFF
--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -518,7 +518,7 @@
                     <!-- SocialSnag -->
                     <a href="https://chromewebstore.google.com/detail/socialsnag/llbpeneloehnlaomolbalbmhjncpmnfa" target="_blank" rel="noopener noreferrer" class="group block deckle-card hover:border-accent transition-all duration-300 relative overflow-hidden">
                         <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-accent">
-                            <i data-lucide="download" class="w-6 h-6"></i>
+                            <i data-lucide="download" class="w-6 h-6" aria-hidden="true"></i>
                         </div>
                         <div class="p-6">
                             <div class="text-[10px] text-accent font-bold tracking-[0.3em] uppercase mb-3">Chrome extension</div>
@@ -529,7 +529,7 @@
                             <div class="mt-4 flex flex-wrap gap-2">
                                 <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Manifest V3</span>
                                 <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">ESM</span>
-                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">122 tests</span>
+                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Tested</span>
                             </div>
                         </div>
                         <div class="bg-white/20 px-6 py-2 border-t border-ink/5 flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-mist group-hover:text-accent transition-colors">

--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -515,6 +515,29 @@
                         </div>
                     </a>
 
+                    <!-- SocialSnag -->
+                    <a href="https://chromewebstore.google.com/detail/socialsnag/llbpeneloehnlaomolbalbmhjncpmnfa" target="_blank" rel="noopener noreferrer" class="group block deckle-card hover:border-accent transition-all duration-300 relative overflow-hidden">
+                        <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-accent">
+                            <i data-lucide="download" class="w-6 h-6"></i>
+                        </div>
+                        <div class="p-6">
+                            <div class="text-[10px] text-accent font-bold tracking-[0.3em] uppercase mb-3">Chrome extension</div>
+                            <h4 class="font-display text-xl text-ink font-bold mb-3 group-hover:text-accent transition-colors">SocialSnag</h4>
+                            <p class="text-sm text-mist leading-relaxed">
+                                Right-click to download full-resolution images and videos from Instagram, Twitter/X, Facebook, and Bluesky. No copy-pasting URLs.
+                            </p>
+                            <div class="mt-4 flex flex-wrap gap-2">
+                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Manifest V3</span>
+                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">ESM</span>
+                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">122 tests</span>
+                            </div>
+                        </div>
+                        <div class="bg-white/20 px-6 py-2 border-t border-ink/5 flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-mist group-hover:text-accent transition-colors">
+                            <span>Install from Chrome Web Store</span>
+                            <span>&nearr;</span>
+                        </div>
+                    </a>
+
                     <!-- Database & Systems Glossary -->
                     <a href="/vibe-coding/glossary-database/" class="group block deckle-card hover:border-accent transition-all duration-300 relative overflow-hidden">
                         <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-accent">


### PR DESCRIPTION
## Summary
- Adds SocialSnag Chrome extension card to the "My tools" grid on tools.amditis.tech
- Links to the Chrome Web Store listing (v1.1.0, published today)
- Uses download icon with aria-hidden, Chrome extension category label, and CWS install CTA

Note: this PR also includes OG/Twitter meta tags and Lucide version pin + defer for index.html (pre-existing unstaged changes). The remaining pages get those same changes in PR #44.

## Test plan
- [ ] Verify card renders correctly in the 2-column grid
- [ ] Confirm CWS link opens the correct listing
- [ ] Check Lucide download icon renders with defer attribute