### PR TITLE
Add OG meta tags to all pages, pin Lucide with SRI

### DIFF
--- a/resource-kit/docs/about/index.html
+++ b/resource-kit/docs/about/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About // Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/about/" />
+    <meta property="og:title" content="About | Amditis AI journalism tools" />
+    <meta property="og:description" content="About the Amditis resource kit for journalists using AI coding tools." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="About | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="About the Amditis resource kit for journalists using AI coding tools." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/code-patterns/index.html
+++ b/resource-kit/docs/code-patterns/index.html
@@ -6,6 +6,17 @@
     <title>Code Patterns // Amditis Kit</title>
     <meta name="description" content="Advanced Claude Code patterns for building reliable AI-assisted workflows. Seven core lessons from 2000+ hours of LLM development.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/code-patterns/" />
+    <meta property="og:title" content="Code patterns | Amditis AI journalism tools" />
+    <meta property="og:description" content="Reusable Claude Code patterns for common journalism tasks." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Code patterns | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Reusable Claude Code patterns for common journalism tasks." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/index.html
+++ b/resource-kit/docs/code-patterns/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/lessons/index.html
+++ b/resource-kit/docs/code-patterns/lessons/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/lessons/index.html
+++ b/resource-kit/docs/code-patterns/lessons/index.html
@@ -6,6 +6,17 @@
     <title>Seven Lessons // Code Patterns</title>
     <meta name="description" content="Seven core patterns for reliable Claude Code development. Error logging, commands-as-apps, hooks, context hygiene, subagent control, tool stacks, and prompt engineering.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/code-patterns/lessons/" />
+    <meta property="og:title" content="Code pattern lessons | Amditis AI journalism tools" />
+    <meta property="og:description" content="Lessons learned from using AI coding tools in real journalism workflows." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Code pattern lessons | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Lessons learned from using AI coding tools in real journalism workflows." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/quick-reference/index.html
+++ b/resource-kit/docs/code-patterns/quick-reference/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/quick-reference/index.html
+++ b/resource-kit/docs/code-patterns/quick-reference/index.html
@@ -6,6 +6,17 @@
     <title>Quick Reference // Code Patterns</title>
     <meta name="description" content="Situation-action lookup tables for Claude Code. Quick reference for debugging, workflows, recovery, and optimization.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/code-patterns/quick-reference/" />
+    <meta property="og:title" content="Code patterns quick reference | Amditis AI journalism tools" />
+    <meta property="og:description" content="Quick reference for Claude Code patterns used in journalism projects." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Code patterns quick reference | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Quick reference for Claude Code patterns used in journalism projects." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/skills/index.html
+++ b/resource-kit/docs/code-patterns/skills/index.html
@@ -6,6 +6,17 @@
     <title>Executable Skills // Code Patterns</title>
     <meta name="description" content="Copy-paste skills for Claude Code. /log_error and /log_success commands for systematic feedback loops.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/code-patterns/skills/" />
+    <meta property="og:title" content="Code pattern skills | Amditis AI journalism tools" />
+    <meta property="og:description" content="Reusable Claude Code skill patterns for common journalism data and publishing tasks." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Code pattern skills | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Reusable Claude Code skill patterns for common journalism data and publishing tasks." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/skills/index.html
+++ b/resource-kit/docs/code-patterns/skills/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         input[type="range"] {

--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         input[type="range"] {

--- a/resource-kit/docs/glossary/index.html
+++ b/resource-kit/docs/glossary/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glossary // Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/glossary/" />
+    <meta property="og:title" content="Glossary | Amditis AI journalism tools" />
+    <meta property="og:description" content="Key terms for journalists using AI coding tools: context, tokens, hooks, skills, and more." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Glossary | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Key terms for journalists using AI coding tools: context, tokens, hooks, skills, and more." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/html-editor/index.html
+++ b/resource-kit/docs/html-editor/index.html
@@ -24,7 +24,7 @@
 
     <!-- Tailwind & Libraries -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
     <script>

--- a/resource-kit/docs/html-editor/index.html
+++ b/resource-kit/docs/html-editor/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HTML EDITOR // AMDITIS</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/html-editor/" />
+    <meta property="og:title" content="HTML editor | Amditis AI journalism tools" />
+    <meta property="og:description" content="A simple HTML editor for journalists building web content with AI assistance." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="HTML editor | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="A simple HTML editor for journalists building web content with AI assistance." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -13,7 +24,7 @@
 
     <!-- Tailwind & Libraries -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
     <script>

--- a/resource-kit/docs/language-guide/index.html
+++ b/resource-kit/docs/language-guide/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Language Guide // Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/language-guide/" />
+    <meta property="og:title" content="Language guide | Amditis AI journalism tools" />
+    <meta property="og:description" content="How to write clear, effective prompts and context for AI coding tools in newsrooms." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Language guide | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="How to write clear, effective prompts and context for AI coding tools in newsrooms." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/llm-advisor-doc/index.html
+++ b/resource-kit/docs/llm-advisor-doc/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LLM Advisor // Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/llm-advisor-doc/" />
+    <meta property="og:title" content="LLM advisor documentation | Amditis AI journalism tools" />
+    <meta property="og:description" content="How to use the Amditis LLM Advisor to find the right AI model for your journalism task." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="LLM advisor documentation | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="How to use the Amditis LLM Advisor to find the right AI model for your journalism task." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -17,7 +28,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/llm-advisor-doc/index.html
+++ b/resource-kit/docs/llm-advisor-doc/index.html
@@ -28,7 +28,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/llm-advisor/ai-showcase/index.html
+++ b/resource-kit/docs/llm-advisor/ai-showcase/index.html
@@ -11,9 +11,20 @@
     <script src="/assets/amditis-config.js"></script>
     
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/llm-advisor/ai-showcase/" />
+    <meta property="og:title" content="AI showcase | Amditis AI journalism tools" />
+    <meta property="og:description" content="Examples of AI tools in action for journalism tasks." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AI showcase | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Examples of AI tools in action for journalism tasks." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-mono bg-void text-chrome">

--- a/resource-kit/docs/llm-advisor/archive/llm-advisor-original-20251124.html
+++ b/resource-kit/docs/llm-advisor/archive/llm-advisor-original-20251124.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LLM journalism tool advisor</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>LLM journalism tool advisor (archived)</title>
     
     <!-- This script loads Tailwind CSS, which is the framework used for all styling. -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/resource-kit/docs/llm-advisor/index.html
+++ b/resource-kit/docs/llm-advisor/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* App Specific Overrides */

--- a/resource-kit/docs/llm-advisor/index.html
+++ b/resource-kit/docs/llm-advisor/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LLM Advisor | Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/llm-advisor/" />
+    <meta property="og:title" content="LLM advisor | Amditis AI journalism tools" />
+    <meta property="og:description" content="Find the right AI model for your journalism task. Compare Claude, GPT, Gemini, and more." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="LLM advisor | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Find the right AI model for your journalism task. Compare Claude, GPT, Gemini, and more." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* App Specific Overrides */

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Merriweather:ital,wght@0,300;0,400;0,700;1,300&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
 
     <!-- Icons (Lucide) -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <!-- Glossary styles -->
     <link rel="stylesheet" href="/assets/glossary.css">

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Merriweather:ital,wght@0,300;0,400;0,700;1,300&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
 
     <!-- Icons (Lucide) -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <!-- Glossary styles -->
     <link rel="stylesheet" href="/assets/glossary.css">

--- a/resource-kit/docs/persistent-sessions/index.html
+++ b/resource-kit/docs/persistent-sessions/index.html
@@ -6,11 +6,22 @@
     <title>Persistent Claude Sessions // Amditis Kit</title>
     <meta name="description" content="Keep Claude Code running while you switch devices, close your laptop, or step away. Set up persistent tmux sessions on a headless server with Cockpit.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/persistent-sessions/" />
+    <meta property="og:title" content="Persistent Claude sessions | Amditis AI journalism tools" />
+    <meta property="og:description" content="How to keep Claude Code sessions alive across multiple tasks using tmux." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Persistent Claude sessions | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="How to keep Claude Code sessions alive across multiple tasks using tmux." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .sidebar-nav { position: sticky; top: 100px; }

--- a/resource-kit/docs/persistent-sessions/index.html
+++ b/resource-kit/docs/persistent-sessions/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .sidebar-nav { position: sticky; top: 100px; }

--- a/resource-kit/docs/quick-reference-card/index.html
+++ b/resource-kit/docs/quick-reference-card/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quick Ref // Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/quick-reference-card/" />
+    <meta property="og:title" content="Quick reference card | Amditis AI journalism tools" />
+    <meta property="og:description" content="One-page reference for Claude Code commands, prompting patterns, and common tasks." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Quick reference card | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="One-page reference for Claude Code commands, prompting patterns, and common tasks." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/quick-reference-card/index.html
+++ b/resource-kit/docs/quick-reference-card/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/style-guide/index.html
+++ b/resource-kit/docs/style-guide/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Amditis // System Guide</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/style-guide/" />
+    <meta property="og:title" content="System guide | Amditis AI journalism tools" />
+    <meta property="og:description" content="A guide to the Amditis design system for AI journalism tools and resources." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="System guide | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="A guide to the Amditis design system for AI journalism tools and resources." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -6,6 +6,17 @@
     <title>Terminal Setup // Amditis Kit</title>
     <meta name="description" content="Complete guide to setting up your terminal for Claude Code, Gemini CLI, and Codex. Includes status line configuration for all platforms.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/terminal-setup/" />
+    <meta property="og:title" content="Terminal setup | Amditis AI journalism tools" />
+    <meta property="og:description" content="How to set up your terminal and install Claude Code, Gemini CLI, and related tools." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Terminal setup | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="How to set up your terminal and install Claude Code, Gemini CLI, and related tools." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -13,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/tool-stacks/index.html
+++ b/resource-kit/docs/tool-stacks/index.html
@@ -6,6 +6,17 @@
     <title>Tool Stacks // Amditis Kit</title>
     <meta name="description" content="Low-cost development tool stacks for building and shipping projects without breaking the bank.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/tool-stacks/" />
+    <meta property="og:title" content="Tool stacks | Amditis AI journalism tools" />
+    <meta property="og:description" content="Recommended AI tool combinations for different journalism workflows and newsroom sizes." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tool stacks | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Recommended AI tool combinations for different journalism workflows and newsroom sizes." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -13,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Tool card styling */

--- a/resource-kit/docs/tool-stacks/index.html
+++ b/resource-kit/docs/tool-stacks/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Tool card styling */

--- a/resource-kit/docs/vibe-coding/cheat-sheet/index.html
+++ b/resource-kit/docs/vibe-coding/cheat-sheet/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vibe Coder Cheat Sheet | Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/cheat-sheet/" />
+    <meta property="og:title" content="Vibe coding cheat sheet | Amditis AI journalism tools" />
+    <meta property="og:description" content="One-page reference for AI-assisted coding patterns, prompts, and troubleshooting." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vibe coding cheat sheet | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="One-page reference for AI-assisted coding patterns, prompts, and troubleshooting." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/vibe-coding/cheat-sheet/index.html
+++ b/resource-kit/docs/vibe-coding/cheat-sheet/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/vibe-coding/common-mistakes/index.html
+++ b/resource-kit/docs/vibe-coding/common-mistakes/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Common Mistakes | Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/common-mistakes/" />
+    <meta property="og:title" content="Common vibe coding mistakes | Amditis AI journalism tools" />
+    <meta property="og:description" content="The most frequent mistakes journalists make when using AI coding tools, and how to avoid them." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Common vibe coding mistakes | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="The most frequent mistakes journalists make when using AI coding tools, and how to avoid them." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .danger-card {

--- a/resource-kit/docs/vibe-coding/common-mistakes/index.html
+++ b/resource-kit/docs/vibe-coding/common-mistakes/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .danger-card {

--- a/resource-kit/docs/vibe-coding/essentials/index.html
+++ b/resource-kit/docs/vibe-coding/essentials/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/vibe-coding/essentials/index.html
+++ b/resource-kit/docs/vibe-coding/essentials/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Basics | Vibe Coder Essentials</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/essentials/" />
+    <meta property="og:title" content="Vibe coding essentials | Amditis AI journalism tools" />
+    <meta property="og:description" content="Core concepts for AI-assisted coding: how to delegate, direct, and verify AI work." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vibe coding essentials | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Core concepts for AI-assisted coding: how to delegate, direct, and verify AI work." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -6,10 +6,21 @@
     <title>Database & Systems Glossary | Amditis Kit</title>
     <meta name="description" content="From indexing to consensus — the vocabulary of distributed systems and data engineering.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/glossary-database/" />
+    <meta property="og:title" content="Database glossary | Amditis vibe coding guide" />
+    <meta property="og:description" content="Key database terms for journalists using AI to work with data." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Database glossary | Amditis vibe coding guide" />
+    <meta name="twitter:description" content="Key database terms for journalists using AI to work with data." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
             transition: all 0.2s ease;

--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
             transition: all 0.2s ease;

--- a/resource-kit/docs/vibe-coding/glossary-database/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/term.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);

--- a/resource-kit/docs/vibe-coding/glossary-database/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/term.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title id="page-title">Term | Database Glossary</title>
     <meta name="description" id="page-description" content="">
+    <meta name="robots" content="noindex">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
             transition: all 0.2s ease;

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -6,10 +6,21 @@
     <title>Frontend Engineering Glossary | Amditis Kit</title>
     <meta name="description" content="From hydration to CRDT — the deep vocabulary of modern frontend development.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/glossary-frontend/" />
+    <meta property="og:title" content="Frontend glossary | Amditis vibe coding guide" />
+    <meta property="og:description" content="Key frontend development terms for journalists building with AI assistance." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Frontend glossary | Amditis vibe coding guide" />
+    <meta name="twitter:description" content="Key frontend development terms for journalists building with AI assistance." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
             transition: all 0.2s ease;

--- a/resource-kit/docs/vibe-coding/glossary-frontend/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/term.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);

--- a/resource-kit/docs/vibe-coding/glossary-frontend/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/term.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title id="page-title">Term | Frontend glossary</title>
     <meta name="description" id="page-description" content="">
+    <meta name="robots" content="noindex">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glossary | Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/glossary/" />
+    <meta property="og:title" content="Vibe coding glossary | Amditis AI journalism tools" />
+    <meta property="og:description" content="Terms used in AI-assisted coding: vibe coding, scaffolding, prompting, and more." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vibe coding glossary | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Terms used in AI-assisted coding: vibe coding, scaffolding, prompting, and more." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Glossary card styles */

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Glossary card styles */

--- a/resource-kit/docs/vibe-coding/index.html
+++ b/resource-kit/docs/vibe-coding/index.html
@@ -6,6 +6,17 @@
     <title>Vibe Coding Guide | Amditis Kit</title>
     <meta name="description" content="The vibe coder's guide - Learn to ship code with AI without being a 'real' developer.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/" />
+    <meta property="og:title" content="Vibe coding guide | Amditis AI journalism tools" />
+    <meta property="og:description" content="A practical guide to AI-assisted coding for journalists with no programming background." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Vibe coding guide | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="A practical guide to AI-assisted coding for journalists with no programming background." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -13,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Page-specific enhancements */

--- a/resource-kit/docs/vibe-coding/index.html
+++ b/resource-kit/docs/vibe-coding/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Page-specific enhancements */

--- a/resource-kit/docs/vibe-coding/level-up/index.html
+++ b/resource-kit/docs/vibe-coding/level-up/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Level Up | Amditis Kit</title>
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/vibe-coding/level-up/" />
+    <meta property="og:title" content="Level up vibe coding | Amditis AI journalism tools" />
+    <meta property="og:description" content="Advanced patterns for journalists ready to get more from AI-assisted development." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Level up vibe coding | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Advanced patterns for journalists ready to get more from AI-assisted development." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -12,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/vibe-coding/security/index.html
+++ b/resource-kit/docs/vibe-coding/security/index.html
@@ -26,7 +26,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .rule-item {

--- a/resource-kit/docs/vibe-coding/security/index.html
+++ b/resource-kit/docs/vibe-coding/security/index.html
@@ -26,7 +26,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .rule-item {

--- a/resource-kit/docs/web-ui/index.html
+++ b/resource-kit/docs/web-ui/index.html
@@ -6,6 +6,17 @@
     <title>Signs of Taste in Web UI // Amditis Kit</title>
     <meta name="description" content="18 principles that separate polished web interfaces from everything else. A checklist for shipping with taste.">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.amditis.tech/web-ui/" />
+    <meta property="og:title" content="Web UI | Amditis AI journalism tools" />
+    <meta property="og:description" content="Web interface tools for journalists working with AI-generated content." />
+    <meta property="og:image" content="https://tools.amditis.tech/assets/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Web UI | Amditis AI journalism tools" />
+    <meta name="twitter:description" content="Web interface tools for journalists working with AI-generated content." />
+    <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
@@ -13,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .principle-card {

--- a/resource-kit/docs/web-ui/index.html
+++ b/resource-kit/docs/web-ui/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .principle-card {


### PR DESCRIPTION
## Summary
- Adds Open Graph and Twitter Card meta tags to all HTML pages for social sharing previews
- Pins Lucide icon CDN from `@latest` to `@0.577.0` with `integrity` and `crossorigin` attributes (SRI)
- Adds `defer` to all Lucide script tags to avoid blocking initial render
- Adds `robots noindex` to glossary term templates and archived LLM advisor page
- Marks archived LLM advisor page title with "(archived)"

## Test plan
- [ ] Spot-check OG previews with Facebook/Twitter debugger on a few pages
- [ ] Verify Lucide icons still render on all pages after version pin + defer
- [ ] Confirm `noindex` pages are template/archive pages that shouldn't be indexed
- [ ] Verify SRI hash matches the pinned Lucide version