### PR TITLE
Fix blank cost-calculator page, remove Scrapefruit card

### DIFF
--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -480,12 +480,19 @@ echo "~\$$cost"</pre>
             update();
             lucide.createIcons();
 
-            const observer = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) entry.target.classList.add('visible');
-                });
-            }, { threshold: 0.1 });
-            document.querySelectorAll('.reveal-section').forEach(s => observer.observe(s));
+            if ('IntersectionObserver' in window) {
+                const observer = new IntersectionObserver((entries) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            entry.target.classList.add('visible');
+                            observer.unobserve(entry.target);
+                        }
+                    });
+                }, { threshold: 0.1 });
+                document.querySelectorAll('.reveal-section').forEach(s => observer.observe(s));
+            } else {
+                document.querySelectorAll('.reveal-section').forEach(s => s.classList.add('visible'));
+            }
         });
     </script>
 </body>

--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -479,6 +479,13 @@ echo "~\$$cost"</pre>
         document.addEventListener('DOMContentLoaded', () => {
             update();
             lucide.createIcons();
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) entry.target.classList.add('visible');
+                });
+            }, { threshold: 0.1 });
+            document.querySelectorAll('.reveal-section').forEach(s => observer.observe(s));
         });
     </script>
 </body>

--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -469,29 +469,6 @@
                         </div>
                     </a>
 
-                    <!-- Scrapefruit -->
-                    <a href="https://scrapefruit.amditis.tech/" target="_blank" rel="noopener noreferrer" class="group block deckle-card hover:border-accent transition-all duration-300 relative overflow-hidden">
-                        <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-accent">
-                            <i data-lucide="grape" class="w-6 h-6"></i>
-                        </div>
-                        <div class="p-6">
-                            <div class="text-[10px] text-accent font-bold tracking-[0.3em] uppercase mb-3">Web scraper</div>
-                            <h4 class="font-display text-xl text-ink font-bold mb-3 group-hover:text-accent transition-colors">Scrapefruit</h4>
-                            <p class="text-sm text-mist leading-relaxed">
-                                Visual web scraping with anti-bot bypass. PyWebView GUI + Playwright stealth mode for extracting content from protected sites.
-                            </p>
-                            <div class="mt-4 flex flex-wrap gap-2">
-                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Python</span>
-                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Playwright</span>
-                                <span class="px-2 py-0.5 bg-white/30 text-xs text-mist border border-ink/10">Flask</span>
-                            </div>
-                        </div>
-                        <div class="bg-white/20 px-6 py-2 border-t border-ink/5 flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-mist group-hover:text-accent transition-colors">
-                            <span>Launch app</span>
-                            <span>&nearr;</span>
-                        </div>
-                    </a>
-
                     <!-- AudioBash -->
                     <a href="https://audiobash.app/" target="_blank" rel="noopener noreferrer" class="group block deckle-card hover:border-accent transition-all duration-300 relative overflow-hidden">
                         <div class="absolute top-0 right-0 p-3 opacity-30 group-hover:opacity-100 transition-opacity text-accent">


### PR DESCRIPTION
## Summary
- Cost calculator page was completely blank because it uses `reveal-section` CSS class (starts at `opacity: 0`) but was missing the `IntersectionObserver` JS that adds the `.visible` class. Added the observer.
- Removes Scrapefruit card from the "My tools" grid per Joe's request.

## Test plan
- [ ] Verify cost-calculator page renders and sliders work
- [ ] Verify Scrapefruit card is gone from homepage
- [ ] Verify remaining tool cards still display correctly