### PR TITLE
Fix Lucide defer race condition and scope card transitions

### DIFF
--- a/resource-kit/docs/about/index.html
+++ b/resource-kit/docs/about/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/code-patterns/index.html
+++ b/resource-kit/docs/code-patterns/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/lessons/index.html
+++ b/resource-kit/docs/code-patterns/lessons/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/quick-reference/index.html
+++ b/resource-kit/docs/code-patterns/quick-reference/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/code-patterns/skills/index.html
+++ b/resource-kit/docs/code-patterns/skills/index.html
@@ -29,7 +29,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         input[type="range"] {

--- a/resource-kit/docs/glossary/index.html
+++ b/resource-kit/docs/glossary/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/html-editor/index.html
+++ b/resource-kit/docs/html-editor/index.html
@@ -24,7 +24,7 @@
 
     <!-- Tailwind & Libraries -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
     <script>

--- a/resource-kit/docs/language-guide/index.html
+++ b/resource-kit/docs/language-guide/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/llm-advisor-doc/index.html
+++ b/resource-kit/docs/llm-advisor-doc/index.html
@@ -28,7 +28,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         body {

--- a/resource-kit/docs/llm-advisor/ai-showcase/index.html
+++ b/resource-kit/docs/llm-advisor/ai-showcase/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-mono bg-void text-chrome">

--- a/resource-kit/docs/llm-advisor/index.html
+++ b/resource-kit/docs/llm-advisor/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* App Specific Overrides */

--- a/resource-kit/docs/llm-advisor/vibe-coding/index.html
+++ b/resource-kit/docs/llm-advisor/vibe-coding/index.html
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Merriweather:ital,wght@0,300;0,400;0,700;1,300&family=Space+Grotesk:wght@300;500;700&display=swap" rel="stylesheet">
 
     <!-- Icons (Lucide) -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <!-- Glossary styles -->
     <link rel="stylesheet" href="/assets/glossary.css">

--- a/resource-kit/docs/persistent-sessions/index.html
+++ b/resource-kit/docs/persistent-sessions/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .sidebar-nav { position: sticky; top: 100px; }

--- a/resource-kit/docs/quick-reference-card/index.html
+++ b/resource-kit/docs/quick-reference-card/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/style-guide/index.html
+++ b/resource-kit/docs/style-guide/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/tool-stacks/index.html
+++ b/resource-kit/docs/tool-stacks/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Tool card styling */

--- a/resource-kit/docs/vibe-coding/cheat-sheet/index.html
+++ b/resource-kit/docs/vibe-coding/cheat-sheet/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         @media print {

--- a/resource-kit/docs/vibe-coding/common-mistakes/index.html
+++ b/resource-kit/docs/vibe-coding/common-mistakes/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .danger-card {

--- a/resource-kit/docs/vibe-coding/essentials/index.html
+++ b/resource-kit/docs/vibe-coding/essentials/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Accordion animations */

--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -20,10 +20,10 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
-            transition: all 0.2s ease;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
             cursor: pointer;
         }
         .term-card:hover {

--- a/resource-kit/docs/vibe-coding/glossary-database/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/term.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);
@@ -22,7 +22,7 @@
             padding-left: 1rem;
         }
         .related-card {
-            transition: all 0.18s ease;
+            transition: transform 0.18s ease, border-color 0.18s ease;
         }
         .related-card:hover {
             border-color: var(--accent) !important;

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -20,10 +20,10 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {
-            transition: all 0.2s ease;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
             cursor: pointer;
         }
         .term-card:hover {

--- a/resource-kit/docs/vibe-coding/glossary-frontend/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/term.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/amditis-main.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/assets/amditis-config.js"></script>
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {
             font-family: var(--font-display, 'Fraunces', serif);
@@ -22,7 +22,7 @@
             padding-left: 1rem;
         }
         .related-card {
-            transition: all 0.18s ease;
+            transition: transform 0.18s ease, border-color 0.18s ease;
         }
         .related-card:hover {
             border-color: var(--accent) !important;

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -23,12 +23,12 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Glossary card styles */
         .glossary-card {
-            transition: all 0.2s ease;
+            transition: border-color 0.2s ease;
         }
 
         .glossary-card:hover {

--- a/resource-kit/docs/vibe-coding/index.html
+++ b/resource-kit/docs/vibe-coding/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         /* Page-specific enhancements */

--- a/resource-kit/docs/vibe-coding/level-up/index.html
+++ b/resource-kit/docs/vibe-coding/level-up/index.html
@@ -23,7 +23,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/vibe-coding/security/index.html
+++ b/resource-kit/docs/vibe-coding/security/index.html
@@ -26,7 +26,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .rule-item {

--- a/resource-kit/docs/web-ui/index.html
+++ b/resource-kit/docs/web-ui/index.html
@@ -24,7 +24,7 @@
     <script src="/assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script defer src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>
         .principle-card {


### PR DESCRIPTION
## Summary

- Removed `defer` attribute from Lucide script tags across all 30 HTML files — deferred scripts execute after HTML parsing but inline `<script>` blocks calling `lucide.createIcons()` run immediately, causing `ReferenceError: lucide is not defined` and blank term detail pages
- Scoped `transition: all` to specific properties (`transform`, `box-shadow`, `border-color`) on glossary card classes to stop layout dimension changes from Lucide icon injection being animated (cards floating up/down on load)

## Test plan

- [ ] Visit https://tools.amditis.tech/vibe-coding/glossary-frontend/ and confirm cards render without floating/bouncing
- [ ] Click any term card and confirm the term detail page loads (not blank)
- [ ] Visit https://tools.amditis.tech/vibe-coding/glossary-database/ and confirm same behavior
- [ ] Click a database term card and confirm it loads
- [ ] Hard refresh (Ctrl+Shift+R) pages to verify no cache dependency
- [ ] Hover over cards and confirm hover effects (lift, shadow, border color) still work