### PR TITLE
Batch DOM insertions and scope cat-tab transitions

### DIFF
--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -35,7 +35,7 @@
             color: var(--accent);
         }
         .cat-tab {
-            transition: all 0.18s ease;
+            transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
             white-space: nowrap;
         }
         .cat-tab.active {
@@ -160,13 +160,15 @@
 (function() {
     // ── Build category tabs ──────────────────────────────
     const tabContainer = document.getElementById('cat-tabs');
+    const tabFrag = document.createDocumentFragment();
     GLOSSARY_META.categories.forEach(cat => {
         const btn = document.createElement('button');
         btn.className = 'cat-tab px-4 py-1.5 border border-ink/20 rounded text-xs font-medium';
         btn.dataset.cat = cat.id;
         btn.textContent = cat.label;
-        tabContainer.appendChild(btn);
+        tabFrag.appendChild(btn);
     });
+    tabContainer.appendChild(tabFrag);
 
     // ── Render term cards ────────────────────────────────
     const grid = document.getElementById('terms-grid');
@@ -195,7 +197,9 @@
         return card;
     }
 
-    TERMS.forEach(t => grid.appendChild(termCard(t)));
+    const gridFrag = document.createDocumentFragment();
+    TERMS.forEach(t => gridFrag.appendChild(termCard(t)));
+    grid.appendChild(gridFrag);
 
     // Update badge count
     document.getElementById('term-count-badge').textContent = `${TERMS.length} Terms`;

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -35,7 +35,7 @@
             color: var(--accent);
         }
         .cat-tab {
-            transition: all 0.18s ease;
+            transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
             white-space: nowrap;
         }
         .cat-tab.active {
@@ -159,13 +159,15 @@
 <script>
 (function() {
     const tabContainer = document.getElementById('cat-tabs');
+    const tabFrag = document.createDocumentFragment();
     GLOSSARY_META.categories.forEach(cat => {
         const btn = document.createElement('button');
         btn.className = 'cat-tab px-4 py-1.5 border border-ink/20 rounded text-xs font-medium';
         btn.dataset.cat = cat.id;
         btn.textContent = cat.label;
-        tabContainer.appendChild(btn);
+        tabFrag.appendChild(btn);
     });
+    tabContainer.appendChild(tabFrag);
 
     const grid = document.getElementById('terms-grid');
     const catColors = {};
@@ -193,7 +195,9 @@
         return card;
     }
 
-    TERMS.forEach(t => grid.appendChild(termCard(t)));
+    const gridFrag = document.createDocumentFragment();
+    TERMS.forEach(t => gridFrag.appendChild(termCard(t)));
+    grid.appendChild(gridFrag);
 
     document.getElementById('term-count-badge').textContent = `${TERMS.length} Terms`;
     lucide.createIcons();


### PR DESCRIPTION
## Summary

Follow-up to #46 (merged). The first PR fixed the Lucide `defer` race condition and scoped `.term-card` transitions, but cards were still shifting on load because:

- **88 individual `appendChild` calls** each trigger a browser reflow — now batched into a single `DocumentFragment` insertion
- **`.cat-tab` still had `transition: all`** — each tab button insertion was being animated as it changed dimensions

## Test plan

- [ ] Hard refresh glossary-frontend page — cards should appear without any visible shifting/bobbing
- [ ] Hard refresh glossary-database page — same behavior
- [ ] Category tab hover effects still work (background + text color change)
- [ ] Card hover effects still work (lift + shadow + border)