### PR TITLE
Fix SVG style leak causing card bobbing

### DIFF
--- a/resource-kit/docs/vibe-coding/glossary-frontend/data.js
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/data.js
@@ -1549,10 +1549,10 @@ const TERMS = [
     category: "performance",
     svg: `<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .block { animation: pulse 1s ease-in-out infinite alternate; }
+    .svg-block { animation: pulse 1s ease-in-out infinite alternate; }
     @keyframes pulse { from { opacity: 1; } to { opacity: 0.3; } }
   </style>
-  <rect x="15" y="45" width="90" height="30" rx="4" fill="#3d4b40" class="block"/>
+  <rect x="15" y="45" width="90" height="30" rx="4" fill="#3d4b40" class="svg-block"/>
   <text x="60" y="65" font-size="9" fill="white" text-anchor="middle">BLOCKED</text>
   <rect x="5" y="10" width="30" height="20" rx="3" fill="#3d4b40" opacity="0.4"/>
   <text x="20" y="24" font-size="7" fill="white" text-anchor="middle">HTML</text>
@@ -1969,12 +1969,12 @@ const TERMS = [
     category: "performance",
     svg: `<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
   <style>
-    .block { animation: shift 1.5s ease-in-out infinite alternate; }
+    .svg-shift { animation: shift 1.5s ease-in-out infinite alternate; }
     @keyframes shift { from { transform: translateY(0); } to { transform: translateY(20px); } }
   </style>
   <rect x="15" y="20" width="90" height="15" rx="3" fill="#3d4b40" opacity="0.5"/>
   <rect x="15" y="42" width="60" height="12" rx="3" fill="#3d4b40" opacity="0.5"/>
-  <rect x="15" y="60" width="90" height="20" rx="3" fill="#3d4b40" class="block"/>
+  <rect x="15" y="60" width="90" height="20" rx="3" fill="#3d4b40" class="svg-shift"/>
   <rect x="15" y="88" width="70" height="12" rx="3" fill="#3d4b40" opacity="0.3"/>
   <line x1="112" y1="60" x2="112" y2="80" stroke="#3d4b40" stroke-width="1.5" marker-end="url(#arr2)"/>
   <text x="60" y="112" font-size="7" fill="#3d4b40" text-anchor="middle">unexpected shift</text>


### PR DESCRIPTION
## Summary

**Root cause found.** Two SVGs in `data.js` had inline `<style>` tags using `.block` as a class name. SVG styles are not scoped — they leak into the entire document. Since every term card has Tailwind's `block` class (`display: block`), the SVG animation rules applied to every card:

```css
/* This was inside an SVG but applied globally */
.block { animation: shift 1.5s ease-in-out infinite alternate; }
@keyframes shift { 0% { translateY(0); } 100% { translateY(20px); } }
```

**Fix:** Renamed the SVG classes from `.block` to `.svg-block` and `.svg-shift`.

## Test plan

- [ ] Frontend glossary cards no longer bob up and down
- [ ] The "Render-blocking resources" SVG thumbnail still animates (pulse effect)
- [ ] The "Cumulative Layout Shift" SVG thumbnail still animates (shift effect)
- [ ] Database glossary unaffected