### PR TITLE
Fix glossary filter tabs not hiding cards

### DIFF
--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -52,7 +52,7 @@
             border-color: var(--accent);
             box-shadow: 0 0 0 3px rgba(61,75,64,0.12);
         }
-        .term-hidden { display: none; }
+        .term-hidden { display: none !important; }
         .highlight {
             background: rgba(61,75,64,0.15);
             border-radius: 2px;

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -52,7 +52,7 @@
             border-color: var(--accent);
             box-shadow: 0 0 0 3px rgba(61,75,64,0.12);
         }
-        .term-hidden { display: none; }
+        .term-hidden { display: none !important; }
         .highlight {
             background: rgba(61,75,64,0.15);
             border-radius: 2px;


### PR DESCRIPTION
## Summary

Category filter tabs weren't visually hiding cards. The JS correctly adds `.term-hidden` class but Tailwind CDN's `.block { display: block }` rule is injected later in the cascade and wins over `.term-hidden { display: none }`.

Fix: `!important` on `.term-hidden`.

## Test plan

- [ ] Click any category tab — only matching cards should be visible
- [ ] Click "All" — all 88 cards visible
- [ ] Search still filters correctly
- [ ] Same behavior on database glossary