### PR TITLE
Remove stale "GitHub Actions suspended" note

### DIFF
--- a/resource-kit/docs/llm-advisor/CLAUDE.md
+++ b/resource-kit/docs/llm-advisor/CLAUDE.md
@@ -1,15 +1,5 @@
 # CLAUDE.md
 
-
-## GitHub Actions suspended (account-wide)
-
-GitHub Actions are disabled on the entire `jamditis` GitHub account until further notice. This means:
-- **No CI/CD pipelines will run** — builds, tests, deploys all fail silently
-- **GitHub Pages deploys won't work** — even "legacy" static deploys that used Actions under the hood
-- **No automated workflows** — PR checks, scheduled jobs, release automation are all dead
-
-**For any project that previously deployed via GitHub Actions or GitHub Pages, you must use an alternative** (manual deploy, Cloudflare Pages, Firebase Hosting, direct FTP, etc.). Do not create or rely on `.github/workflows/` files.
-
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Bug-fixing workflow


### PR DESCRIPTION
Actions are enabled on the `jamditis` account again (confirmed 2026-04-21). The suspension note at the top of `resource-kit/docs/llm-advisor/CLAUDE.md` would otherwise keep steering future work away from `.github/workflows/` and GitHub Pages for no reason.

## Summary
- Remove the 10-line "GitHub Actions suspended (account-wide)" block from `resource-kit/docs/llm-advisor/CLAUDE.md`.
- Part of a sweep across 4 repos. Companion PRs: jamditis/njcic#38, jamditis/stash#27, plus ccm (pending).

## Test plan
- [x] File renders cleanly — only removed text, no new content.
- [x] No other references to the suspension elsewhere in this repo on master.