### PR TITLE
Bump case-study badges to Opus 4.8; pin index.html Lucide

### DIFF
--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -60,7 +60,7 @@
     <script src="assets/amditis-config.js"></script>
 
     <!-- Icons -->
-    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 <script src="/assets/ask-ai.js" defer></script>
 </head>
 <body class="antialiased font-sans bg-canvas text-ink">

--- a/resource-kit/docs/llm-advisor/data/case-studies.json
+++ b/resource-kit/docs/llm-advisor/data/case-studies.json
@@ -1,7 +1,7 @@
 [
   {
     "title": "Building the Amditis resource kit with Claude Code",
-    "tool": "Claude Opus 4.6",
+    "tool": "Claude Opus 4.8",
     "journalist": "Center for Cooperative Media",
     "challenge": "Creating a complete, interactive resource kit for journalists learning AI tools required building multiple web pages, interactive decision trees, and maintaining consistent theming across dozens of files.",
     "solution": "Used Claude Code with custom skills and hooks to build the entire resource kit. Created specialized skills for the Amditis theme, JSON data management, and content validation. Set up hooks to automatically validate model names and theme classes after each edit.",
@@ -12,7 +12,7 @@
   },
   {
     "title": "Automating newsroom data pipelines with Claude Code hooks",
-    "tool": "Claude Opus 4.6",
+    "tool": "Claude Opus 4.8",
     "journalist": "Data Journalism Team",
     "challenge": "A newsroom needed to process daily data feeds, validate incoming data, and generate alerts when anomalies were detected—but the manual process was error-prone and time-consuming.",
     "solution": "Implemented a Claude Code workflow with PostToolUse hooks that automatically validate data after each processing step. Created a SessionStart hook that checks for new data files and a forked-context skill that runs parallel validation across multiple data sources.",
@@ -23,7 +23,7 @@
   },
   {
     "title": "Rapid prototyping interactive graphics with Claude Code",
-    "tool": "Claude Opus 4.6",
+    "tool": "Claude Opus 4.8",
     "journalist": "Graphics Team",
     "challenge": "Creating interactive data visualizations for breaking news requires fast iteration, but the traditional design-develop-test cycle was too slow for deadline-driven journalism.",
     "solution": "Used Claude Code's ability to run a local server and iterate on HTML/CSS/JavaScript in real-time. Created skills for common chart types and the newsroom's design system. Plan mode helped architect complex multi-chart projects before diving into code.",


### PR DESCRIPTION
Follow-ups after #65.

## Changes
- **Case-study badges → Opus 4.8** (`case-studies.json`): the three kit-related case studies ("Building the Amditis resource kit," "Automating newsroom data pipelines," "Rapid prototyping interactive graphics") now show `Claude Opus 4.8` instead of 4.6. These badges are display-only (colored via `getPillClasses`, not model-info lookups), so the change is safe. The genuinely-external case studies (e.g. CT Mirror's `ChatGPT o3`) are left as historical fact.
- **Pin `index.html` Lucide** — it was the one live page still on unpinned `https://unpkg.com/lucide@latest`. Pinned to the same `lucide@0.577.0/dist/umd/lucide.min.js` build (with integrity hash) the other 30 pages use.

## Why not bump Lucide to v1?
The originally-flagged `0.577.0 → 1.21.0` upgrade turns out to be a **breaking** change, not a version bump: Lucide v1 **removed the UMD build** that the whole site depends on (`<script>` tag + global `lucide.createIcons()`), and also renamed some icons and removed brand icons. `unpkg.com/lucide@latest` resolving to v1 is exactly why pinning `index.html` matters here. A real v1 migration needs browser testing of icon rendering across all pages, so it's deferred to a dedicated, tested change.

`case-studies.json` re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4yCSGMtBRqPbEuZGivNMK)_