### PR TITLE
Sync the journalism-skills count to a self-updating "50+"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Reusable skills for Claude Code that extend its capabilities for specific workfl
 |-------|-------------|------|
 | [test-first-bugs](./skills/test-first-bugs/) | Test-driven bug fixing workflow | Local |
 | [pdf-design](./skills/pdf-design/) | PDF reports and proposals with interactive editing, brand system, budget tables | Local |
-| [journalism skills](https://github.com/jamditis/claude-skills-journalism) | 30+ skills for journalism, media, and academia | External repo |
+| [journalism skills](https://github.com/jamditis/claude-skills-journalism) | 50+ skills for journalism, media, and academia | External repo |
 
 ### Installing plugins (recommended for PDF Playground)
 


### PR DESCRIPTION
The skills table called the linked `claude-skills-journalism` repo "30+ skills." That repo now ships 56 `SKILL.md` files, so "30+" reads as stale.

Switched to "50+" — self-updating phrasing that stays honest as skills are added, rather than a hard number that drifts.

Refs jamditis/claude-skills-journalism#125 (the `tools` half; mooc-starter-kit gets the same fix in a sibling PR).