### PR TITLE
Cap guard for copilot-instructions files (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,8 @@ Template (two sections):
 
 See `rosen-frontend/.github/copilot-instructions.md` for the reference layout. Keep each file well under 4,000 characters; if a repo's project bug classes grow, that budget is for them, not for re-restated globals.
 
+`scripts/check-copilot-instructions.sh` enforces the cap so the sweep is not manual: it prints each repo's `.github/copilot-instructions.md` size, warns near the cap, exits non-zero on any file over it, and advises where a file still restates prose-style globals the bot ignores. Run it with no arguments to scan every repo under `~/projects`, or pass repo roots for a specific set (passing explicit roots also avoids counting incidental worktree clones, which carry their own copy of the file). `scripts/check-copilot-instructions.test.sh` covers it.
+
 Background: `tools` issue #59, and `MEMORY.md` → `reference_copilot_pr_review_reading_scope.md` for the underlying constraint.
 
 ## Things to avoid

--- a/scripts/check-copilot-instructions.sh
+++ b/scripts/check-copilot-instructions.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-copilot-instructions.sh -- guard every repo's .github/copilot-instructions.md
+# against the ~4,000-character silent-truncation cap the Copilot PR review bot enforces.
+#
+# Copilot's PR review bot reads .github/copilot-instructions.md with a roughly
+# 4,000-char cap and silently drops anything past it (tools#59). Three files once
+# reached that cap by restating ~1,700 chars of prose-style globals the bot cannot
+# enforce anyway; the fix was to keep each file to bot-enforceable rules plus the
+# repo's own bug classes, well under cap. Holding that line has meant a manual
+# `wc -c` sweep. This turns that sweep into one repeatable check: it prints each
+# file's size, warns when a file creeps toward the cap, and exits non-zero if any
+# file is over it, so a growing bug-class list cannot push a repo back into silent
+# truncation unnoticed.
+#
+# It also runs an advisory scan for the prose-style globals (sentence case, banned
+# words) that the bot ignores, so a file that starts restating them again is flagged
+# before it eats the cap budget. The advisory never changes the exit code; only the
+# hard cap does.
+#
+# Usage:
+#   scripts/check-copilot-instructions.sh [REPO_DIR ...]
+#
+# With no arguments it scans every repo directory under ~/projects. Pass one or more
+# repo roots to check a specific set. Exit code is 0 when every file is under the
+# cap, 1 when any file is over it.
+#
+# Background: tools/CLAUDE.md "Copilot review instructions", tools issue #59.
+
+set -euo pipefail
+
+CAP=4000    # the bot's silent-truncation ceiling
+WARN=3600   # "well under 4,000" headroom: flag a file creeping toward the cap
+
+usage() {
+  # Print the header comment (up to the first blank line after the shebang) as help.
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+case "${1:-}" in
+  -h | --help) usage ;;
+esac
+
+# Resolve the repo list: explicit args, or every immediate subdirectory of ~/projects.
+repos=()
+if [[ $# -gt 0 ]]; then
+  repos=("$@")
+else
+  for d in "$HOME"/projects/*/; do
+    [[ -d "$d" ]] && repos+=("${d%/}")
+  done
+fi
+
+if [[ ${#repos[@]} -eq 0 ]]; then
+  echo "no repos to check (looked under ~/projects; pass repo roots as arguments)" >&2
+  exit 0
+fi
+
+# Prose-style globals the bot cannot enforce. A line stating one of these as a rule
+# is wasted cap budget (tools#59); a line noting they are intentionally omitted is
+# not, so the exclusion below skips the "we drop these" notes the cleaned files carry.
+# The exclusion matches only the meta-note vocabulary (omitted, excluded, the bot,
+# a style linter). It deliberately does NOT match "do not", because a negative-form
+# rule -- "Do not use Title Case" -- is a real restatement to flag, not a meta-note.
+PROSE_MARKERS='sentence case|banned word|title case|emoji'
+PROSE_EXCLUDE='intentional|omit|exclud|not enforce|bot ignores|style linter|not read'
+
+checked=0 over=0 near=0 advisories=0
+printf '%-30s %8s  %s\n' "REPO" "CHARS" "STATUS"
+printf '%-30s %8s  %s\n' "----" "-----" "------"
+
+for repo in "${repos[@]}"; do
+  file="$repo/.github/copilot-instructions.md"
+  [[ -f "$file" ]] || continue
+  checked=$((checked + 1))
+  name="$(basename "$repo")"
+  chars="$(wc -c <"$file" | tr -d ' ')"
+
+  if [[ "$chars" -gt "$CAP" ]]; then
+    status="OVER CAP (+$((chars - CAP)) past $CAP -- tail is being truncated)"
+    over=$((over + 1))
+  elif [[ "$chars" -ge "$WARN" ]]; then
+    status="near cap ($((CAP - chars)) left)"
+    near=$((near + 1))
+  else
+    status="ok"
+  fi
+  printf '%-30s %8s  %s\n' "$name" "$chars" "$status"
+
+  # Advisory: prose-style-globals restatement, excluding the "omit these" notes.
+  hits="$(grep -inE "$PROSE_MARKERS" "$file" | grep -ivE "$PROSE_EXCLUDE" || true)"
+  if [[ -n "$hits" ]]; then
+    advisories=$((advisories + 1))
+    while IFS= read -r line; do
+      printf '  advisory: prose-style rule the bot ignores -> %s\n' "${line}"
+    done <<<"$hits"
+  fi
+done
+
+echo
+if [[ "$checked" -eq 0 ]]; then
+  echo "no .github/copilot-instructions.md files found in the ${#repos[@]} repo(s) scanned"
+  exit 0
+fi
+
+echo "checked $checked file(s): $over over cap, $near near cap, $advisories with prose-globals advisories"
+if [[ "$over" -gt 0 ]]; then
+  echo "FAIL: $over file(s) over the ${CAP}-char cap are losing their tail to silent truncation" >&2
+  exit 1
+fi
+echo "OK: every file is under the ${CAP}-char cap"

--- a/scripts/check-copilot-instructions.test.sh
+++ b/scripts/check-copilot-instructions.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Test for check-copilot-instructions.sh: builds fixture repos in a temp dir and
+# asserts the guard's exit code and output on under-cap, near-cap, and over-cap
+# files, plus the prose-globals advisory. Run: scripts/check-copilot-instructions.test.sh
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+guard="$here/check-copilot-instructions.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0 fail=0
+ok() { echo "  [PASS] $1"; pass=$((pass + 1)); }
+no() { echo "  [FAIL] $1"; fail=$((fail + 1)); }
+
+# check <desc> <cmd...> -- run the command (inheriting any here-string on stdin) and
+# record pass/fail by its exit status. Keeps assertions out of the A && B || C idiom.
+check() { local desc="$1"; shift; if "$@"; then ok "$desc"; else no "$desc"; fi; }
+
+mkfile() { # mkfile <repo> <char-count> <extra-line>
+  local repo="$tmp/$1" n="$2" extra="${3:-}"
+  mkdir -p "$repo/.github"
+  local f="$repo/.github/copilot-instructions.md"
+  # A header line, then filler to reach n bytes, then the optional extra line.
+  { printf '# copilot rules\n'; head -c "$n" </dev/zero | tr '\0' 'x'; [[ -n "$extra" ]] && printf '\n%s\n' "$extra"; } >"$f"
+}
+
+# under cap, no advisory
+mkfile under 200 ""
+# near cap (>= 3600, < 4000)
+mkfile near 3700 ""
+# over cap (> 4000)
+mkfile over 4200 ""
+# under cap but restates a prose-style global the bot ignores (advisory)
+mkfile prosey 200 "Use sentence case, never Title Case."
+# under cap with a "we omit these" note (should NOT advise)
+mkfile omits 200 "Prose-style globals (sentence case, banned words) are intentionally omitted."
+# under cap, restates a prose global as a NEGATIVE rule -- must still be flagged
+mkfile negrule 200 "Do not use Title Case in headings."
+
+echo "=== a clean set (under + near, no over) exits 0 ==="
+out="$("$guard" "$tmp/under" "$tmp/near" 2>&1)"; rc=$?
+check "exit 0 when nothing is over cap" test "$rc" -eq 0
+check "flags the near-cap file" grep -q "near cap" <<<"$out"
+
+echo "=== an over-cap file fails the gate (exit 1) ==="
+out="$("$guard" "$tmp/under" "$tmp/over" 2>&1)"; rc=$?
+check "exit 1 when a file is over cap" test "$rc" -eq 1
+check "labels the over-cap file" grep -q "OVER CAP" <<<"$out"
+
+echo "=== a file exactly at the 4000-char cap is not over (guards the -gt boundary) ==="
+# Written byte-exact, not via mkfile (which prepends a header). A file of exactly CAP
+# bytes must pass: it pins the core comparison at -gt, so a regression to -ge -- which
+# would wrongly flag a 4000-char file as over cap -- fails here and only here.
+mkdir -p "$tmp/boundary/.github"
+head -c 4000 </dev/zero | tr '\0' 'x' >"$tmp/boundary/.github/copilot-instructions.md"
+out="$("$guard" "$tmp/boundary" 2>&1)"; rc=$?
+check "exit 0 for a file exactly at the cap" test "$rc" -eq 0
+check "a file exactly at the cap is not flagged over" test -z "$(grep 'OVER CAP' <<<"$out" || true)"
+
+echo "=== the prose-globals advisory fires, and exit stays 0 ==="
+out="$("$guard" "$tmp/prosey" 2>&1)"; rc=$?
+check "advisory does not change the exit code" test "$rc" -eq 0
+check "flags a restated prose-style rule" grep -q "advisory: prose-style rule" <<<"$out"
+
+echo "=== an 'intentionally omitted' note is not flagged ==="
+out="$("$guard" "$tmp/omits" 2>&1)"
+check "skips the omission note" test -z "$(grep advisory <<<"$out" || true)"
+
+echo "=== a negative-form prose rule is still flagged (not suppressed) ==="
+out="$("$guard" "$tmp/negrule" 2>&1)"
+check "flags 'Do not use Title Case' as a restatement" grep -q "advisory: prose-style rule" <<<"$out"
+
+echo "=== a repo with no copilot file is skipped cleanly ==="
+mkdir -p "$tmp/empty"
+out="$("$guard" "$tmp/empty" 2>&1)"; rc=$?
+check "exit 0 when no file is present" test "$rc" -eq 0
+
+echo
+echo "=== $pass passed, $fail failed ==="
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## What

A guard that keeps every repo's `.github/copilot-instructions.md` under the ~4,000-char cap the Copilot PR review bot silently truncates past (issue #59).

`scripts/check-copilot-instructions.sh` prints each repo's size, warns when a file creeps toward the cap, and exits non-zero if any file is over it. It also runs an advisory scan for the prose-style globals (sentence case, banned words) the bot cannot enforce, so a file that starts restating them again is flagged before it eats the cap budget. The advisory never changes the exit code; only the hard cap does.

`scripts/check-copilot-instructions.test.sh` is an 11-case self-test covering under/near/over cap, the exact 4000-char boundary, the advisory firing without changing the exit code, an "intentionally omitted" note staying unflagged, and a negative-form rule ("Do not use Title Case") still being caught.

## Why this shape

The tracked sweep of trimming the fleet's instruction files was already done by earlier work; what was missing was a way to keep them trimmed. Running the guard now surfaces three repos already over cap and losing their tail (ccm, houseofjawn-dashboard, jawn-map) that the last manual `wc -c` sweep missed. Those are filed as a follow-up rather than fixed here (cross-repo scope).

Progresses #59.

wake-20260708T0905-1b768f
