### PR TITLE
Migrate the build-safe pages off the Tailwind Play CDN (#78)

### DIFF
--- a/resource-kit/docs/code-patterns/skills/index.html
+++ b/resource-kit/docs/code-patterns/skills/index.html
@@ -25,8 +25,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/cost-calculator/index.html
+++ b/resource-kit/docs/cost-calculator/index.html
@@ -19,8 +19,7 @@
     <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png">
 
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>

--- a/resource-kit/docs/glossary/index.html
+++ b/resource-kit/docs/glossary/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/index.html
+++ b/resource-kit/docs/index.html
@@ -62,8 +62,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/language-guide/index.html
+++ b/resource-kit/docs/language-guide/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/persistent-sessions/index.html
+++ b/resource-kit/docs/persistent-sessions/index.html
@@ -19,8 +19,7 @@
     <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
 
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
 
     <style>

--- a/resource-kit/docs/vibe-coding/essentials/index.html
+++ b/resource-kit/docs/vibe-coding/essentials/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/vibe-coding/glossary-database/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/index.html
@@ -18,8 +18,7 @@
     <meta name="twitter:description" content="Key database terms for journalists using AI to work with data." />
     <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {

--- a/resource-kit/docs/vibe-coding/glossary-database/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-database/term.html
@@ -8,8 +8,7 @@
     <meta name="robots" content="noindex">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {

--- a/resource-kit/docs/vibe-coding/glossary-frontend/index.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/index.html
@@ -18,8 +18,7 @@
     <meta name="twitter:description" content="Key frontend development terms for journalists building with AI assistance." />
     <meta name="twitter:image" content="https://tools.amditis.tech/assets/og-image.png" />
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .term-card {

--- a/resource-kit/docs/vibe-coding/glossary-frontend/term.html
+++ b/resource-kit/docs/vibe-coding/glossary-frontend/term.html
@@ -8,8 +8,7 @@
     <meta name="robots" content="noindex">
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <style>
         .prose-section h2 {

--- a/resource-kit/docs/vibe-coding/glossary/index.html
+++ b/resource-kit/docs/vibe-coding/glossary/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/vibe-coding/level-up/index.html
+++ b/resource-kit/docs/vibe-coding/level-up/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/web-ui/index.html
+++ b/resource-kit/docs/web-ui/index.html
@@ -20,8 +20,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/tailwind-build/README.md
+++ b/resource-kit/tailwind-build/README.md
@@ -28,18 +28,19 @@ Keep the two in sync until every page is migrated, then retire the runtime confi
 
 ## Migration status
 
-Migrated to the precompiled stylesheet: 15 static content pages, whose Tailwind
-classes all resolve from the HTML and JS the build scans.
+Migrated to the precompiled stylesheet: every static content page whose Tailwind
+classes all resolve as literals from the HTML and JS the build scans.
 
-Still on the Play CDN, deliberately: pages that generate Tailwind class names at
-runtime (dynamic DOM built in JS, some by string interpolation), and the two pages
-that carry their own inline `tailwind.config`. A static build only ships the classes
-it sees at build time, so migrating these safely needs one of:
+Still on the Play CDN, deliberately, are the pages a static build cannot cover
+without extra work, because it only ships the classes it sees at build time:
 
-- a `safelist` (or a per-page class inventory) that captures the interpolated
-  classes the JS scan cannot, verified page by page, or
-- for the inline-config pages, merging their `theme.extend` into
-  `tailwind.config.js` (watch for palette-name collisions between pages).
+- Class names built at runtime by string interpolation (`bg-${color}`), which the
+  glob scan cannot see: `llm-advisor/index.html`, `llm-advisor/ai-showcase/index.html`,
+  and `terminal-setup/index.html`. Migrating these needs a `safelist` (or a per-page
+  class inventory) that captures the interpolated classes, verified page by page.
+- Pages carrying their own inline `tailwind.config`: `html-editor/index.html` and
+  `llm-advisor/vibe-coding/index.html`. Migrating these needs their `theme.extend`
+  merged into `tailwind.config.js` (watch for palette-name collisions between pages).
 
 The remaining pages are tracked in jamditis/tools#78, so the split stays on the
 record and the production warning gets fully retired.


### PR DESCRIPTION
Refs #78. Migrates 14 of the 19 deferred pages off `cdn.tailwindcss.com` to the precompiled `/assets/tailwind.css`. Leaves 5 genuinely-hard pages on the CDN with a documented reason, so this advances #78 without closing it.

## How the safe subset was chosen

The build globs `../docs/**/*.html` and `../docs/**/*.js`, so a page whose Tailwind classes are all **literals** is already fully captured in `tailwind.css` today, CDN or not. #78 deferred these 19 pessimistically ("each generates classes the build cannot safely capture"), but that conflates two different things:

- `${item.term}` as **text content** between tags -> harmless; the surrounding classes are literal and already captured.
- `${item.color}` **inside a class attribute**, or `hover:${x}` / `bg-${x}` -> genuinely uncapturable.

A precise per-page scan (HTML + each page's referenced JS) for the second kind found:

- **Safe now, migrated here (14):** code-patterns/skills, cost-calculator, glossary, index, language-guide, persistent-sessions, vibe-coding/essentials, vibe-coding/glossary-database/{index,term}, vibe-coding/glossary-frontend/{index,term}, vibe-coding/glossary, vibe-coding/level-up, web-ui.
- **Needs a safelist (interpolated class names), left on CDN:** llm-advisor/index, llm-advisor/ai-showcase, terminal-setup.
- **Needs config merge (own inline `tailwind.config`), left on CDN:** html-editor, llm-advisor/vibe-coding.

Follow-ups filed for the two deferred tiers (linked below).

## Verification

- Rebuilding `tailwind.css` after the swap produced a **byte-identical** file (same sha, 50460 bytes) -> the migration drops no class; the pages' classes were already in the stylesheet.
- The build config's `theme.extend` fully mirrors the runtime `amditis-config.js` being removed (canvas/ink/mist/clay/accent, Fraunces + Plus Jakarta Sans, drift/page-in/ink-spread) -> no custom class loses its definition.
- Arbitrary-value literals like `bg-[#1e1e1e]` / `bg-[#0d1117]` (the terminal mockups in persistent-sessions) are compiled into the stylesheet -- verified `.bg-\[\#1e1e1e\]` and `.bg-\[\#0d1117\]` are present. The build captures arbitrary values from globbed content, so these keep their dark backgrounds; they are **not** a runtime-only CDN feature.
- `amditis-config.js` is retained because the 5 deferred pages still load it; it retires when #78 closes.

## Per-page change

Remove the `cdn.tailwindcss.com` script and the `amditis-config.js` include; add `<link rel="stylesheet" href="/assets/tailwind.css">` exactly where the CDN script was, preserving source order (main.css then tailwind.css). Root `index.html` keeps its relative `assets/` path convention. `tailwind.css` is unchanged, so it is not re-committed.

Out of scope: `llm-advisor/archive/llm-advisor-original-20251124.html` is a dated snapshot, not a live content page in the #78 set, and stays as-is.

wake-20260723T0805-6ff63d