### PR TITLE
Migrate terminal-setup and llm-advisor off the Tailwind Play CDN

### DIFF
--- a/resource-kit/docs/llm-advisor/index.html
+++ b/resource-kit/docs/llm-advisor/index.html
@@ -19,8 +19,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/docs/terminal-setup/index.html
+++ b/resource-kit/docs/terminal-setup/index.html
@@ -20,8 +20,7 @@
 
     <!-- CSS & Config -->
     <link rel="stylesheet" href="/assets/amditis-main.css">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="/assets/amditis-config.js"></script>
+    <link rel="stylesheet" href="/assets/tailwind.css">
 
     <!-- Icons -->
     <script src="https://unpkg.com/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>

--- a/resource-kit/tailwind-build/README.md
+++ b/resource-kit/tailwind-build/README.md
@@ -35,9 +35,10 @@ Still on the Play CDN, deliberately, are the pages a static build cannot cover
 without extra work, because it only ships the classes it sees at build time:
 
 - Class names built at runtime by string interpolation (`bg-${color}`), which the
-  glob scan cannot see: `llm-advisor/index.html`, `llm-advisor/ai-showcase/index.html`,
-  and `terminal-setup/index.html`. Migrating these needs a `safelist` (or a per-page
-  class inventory) that captures the interpolated classes, verified page by page.
+  glob scan cannot see: `llm-advisor/ai-showcase/index.html`, whose cards build
+  their hover and accent classes from a data array. Migrating it needs a `safelist`
+  (or a per-page class inventory) that captures the interpolated classes, verified
+  page by page.
 - Pages carrying their own inline `tailwind.config`: `html-editor/index.html` and
   `llm-advisor/vibe-coding/index.html`. Migrating these needs their `theme.extend`
   merged into `tailwind.config.js` (watch for palette-name collisions between pages).


### PR DESCRIPTION
Follow-up to #78 (after #83): migrates two more resource-kit pages off the Tailwind Play CDN to the precompiled stylesheet.

## What

- `terminal-setup/index.html` and `llm-advisor/index.html`: replace the `cdn.tailwindcss.com` and `amditis-config.js` scripts with `<link rel="stylesheet" href="/assets/tailwind.css">`, matching the already-migrated pages.
- README migration status updated so only `ai-showcase` (real data-array class interpolation) and the two own-inline-config pages stay on the CDN.

## Why these two were safe now

Both were parked as interpolated-class pages, but neither builds Tailwind classes at runtime: their utility classes are all literals in the markup, on the shared V2 palette. The content glob (`../docs/**/*.html`) already scans every page, so their classes were already compiled into the committed `tailwind.css`. No rebuild is needed, and rebuilding under a drifted tailwindcss version would only churn the minified output.

## Verification

Confirmed that every Tailwind utility class token in both pages resolves in the compiled stylesheet. The only unresolved tokens are page-local `<style>` rules, shared `amditis-main.css` classes (which stays loaded), or JS selector hooks that carry no CSS rule.

Remaining on the CDN after this, tracked in #78: `llm-advisor/ai-showcase`, `html-editor`, `llm-advisor/vibe-coding`.

wake-20260723T1405-e4c9de
