### PR TITLE
Count repos, not checkouts, in the copilot-instructions cap guard

### DIFF
--- a/scripts/check-copilot-instructions.sh
+++ b/scripts/check-copilot-instructions.sh
@@ -17,6 +17,14 @@
 # before it eats the cap budget. The advisory never changes the exit code; only the
 # hard cap does.
 #
+# Counts are per repo, not per directory scanned. ~/projects holds worktrees sharing one
+# .git and separate clones of the same upstream, so one over-cap file used to be reported
+# once per checkout: the summary read as nine over-cap repos when there was one file to
+# fix (tools#77). Checkouts are folded by their origin URL and reported as one row, with
+# the largest file in the group shown so a stale sibling cannot hide a truncating one.
+# The advisory scan still reads every checkout, since folding the count must not fold the
+# coverage.
+#
 # Usage:
 #   scripts/check-copilot-instructions.sh [REPO_DIR ...]
 #
@@ -24,7 +32,7 @@
 # repo roots to check a specific set. Exit code is 0 when every file is under the
 # cap, 1 when any file is over it.
 #
-# Background: tools/CLAUDE.md "Copilot review instructions", tools issue #59.
+# Background: tools/CLAUDE.md "Copilot review instructions", tools issues #59 and #77.
 
 set -euo pipefail
 
@@ -65,16 +73,79 @@ fi
 PROSE_MARKERS='sentence case|banned word|title case|emoji'
 PROSE_EXCLUDE='intentional|omit|exclud|not enforce|bot ignores|style linter|not read'
 
-checked=0 over=0 near=0 advisories=0
-printf '%-30s %8s  %s\n' "REPO" "CHARS" "STATUS"
-printf '%-30s %8s  %s\n' "----" "-----" "------"
+# The upstream repo a checkout points at, so the same repo seen through several local
+# checkouts is counted once. The default scan walks ~/projects, which holds worktrees
+# sharing one .git and separate clones of the same upstream; counting each as its own
+# repo made the summary line read as nine over-cap repos when there was one over-cap
+# file (tools#77). The origin URL collapses both cases, since worktrees and clones of a
+# repo all point at the same remote. A checkout with no origin falls back to its shared
+# git directory, which still collapses worktrees, and a directory that is not a repo at
+# all falls back to its own path so it is never merged with anything else.
+repo_identity() {
+  local repo="$1" url common
+  if url="$(git -C "$repo" remote get-url origin 2>/dev/null)" && [[ -n "$url" ]]; then
+    # Normalize so git@github.com:owner/repo.git and https://github.com/owner/repo
+    # resolve to the same identity.
+    url="${url%.git}"
+    url="${url#*://}"
+    url="${url#git@}"
+    url="${url/:/\/}"
+    printf 'origin:%s' "$(printf '%s' "$url" | tr '[:upper:]' '[:lower:]')"
+    return
+  fi
+  if common="$(cd "$repo" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" &&
+    [[ -n "$common" ]]; then
+    [[ "$common" != /* ]] && common="$repo/$common"
+    printf 'gitdir:%s' "$common"
+    return
+  fi
+  printf 'path:%s' "$(cd "$repo" 2>/dev/null && pwd -P || printf '%s' "$repo")"
+}
+
+# Collect every file first, then report one row per upstream repo. Reporting inside the
+# scan loop is what produced the duplicate rows.
+declare -A group_name group_chars group_files group_count group_paths
+order=()
 
 for repo in "${repos[@]}"; do
   file="$repo/.github/copilot-instructions.md"
   [[ -f "$file" ]] || continue
-  checked=$((checked + 1))
   name="$(basename "$repo")"
   chars="$(wc -c <"$file" | tr -d ' ')"
+  key="$(repo_identity "$repo")"
+
+  if [[ -z "${group_count[$key]:-}" ]]; then
+    order+=("$key")
+    group_count[$key]=1
+    group_name[$key]="$name"
+    group_chars[$key]="$chars"
+    group_files[$key]="$file"
+    group_paths[$key]="$name"
+    continue
+  fi
+  group_count[$key]=$((group_count[$key] + 1))
+  group_paths[$key]="${group_paths[$key]}, $name"
+  # Every checkout stays in the list, because the advisory scan below reads all of them.
+  # Folding the count must not fold the coverage: a sibling on a different commit can
+  # restate prose-style globals the representative file does not.
+  group_files[$key]="${group_files[$key]}"$'\n'"$file"
+  # Checkouts of one repo can sit at different commits, so report the largest file in
+  # the group. That is the one that would truncate, and hiding it behind a smaller
+  # sibling would turn the dedup into a way to miss a real over-cap file.
+  if [[ "$chars" -gt "${group_chars[$key]}" ]]; then
+    group_chars[$key]="$chars"
+    group_name[$key]="$name"
+  fi
+done
+
+checked=0 over=0 near=0 advisories=0 duplicates=0
+printf '%-30s %8s  %s\n' "REPO" "CHARS" "STATUS"
+printf '%-30s %8s  %s\n' "----" "-----" "------"
+
+for key in "${order[@]}"; do
+  checked=$((checked + 1))
+  name="${group_name[$key]}"
+  chars="${group_chars[$key]}"
 
   if [[ "$chars" -gt "$CAP" ]]; then
     status="OVER CAP (+$((chars - CAP)) past $CAP -- tail is being truncated)"
@@ -87,8 +158,23 @@ for repo in "${repos[@]}"; do
   fi
   printf '%-30s %8s  %s\n' "$name" "$chars" "$status"
 
-  # Advisory: prose-style-globals restatement, excluding the "omit these" notes.
-  hits="$(grep -inE "$PROSE_MARKERS" "$file" | grep -ivE "$PROSE_EXCLUDE" || true)"
+  if [[ "${group_count[$key]}" -gt 1 ]]; then
+    duplicates=$((duplicates + group_count[$key] - 1))
+    printf '  same repo in %s local checkouts: %s\n' \
+      "${group_count[$key]}" "${group_paths[$key]}"
+  fi
+
+  # Advisory: prose-style-globals restatement, excluding the "omit these" notes. Every
+  # checkout in the group is scanned so a sibling on a different commit is still caught,
+  # and identical findings are collapsed so the folded checkouts do not restore the
+  # duplicate output this change removed.
+  hits=""
+  while IFS= read -r checkout; do
+    [[ -n "$checkout" ]] || continue
+    found="$(grep -inE "$PROSE_MARKERS" "$checkout" | grep -ivE "$PROSE_EXCLUDE" || true)"
+    [[ -n "$found" ]] && hits="${hits}${found}"$'\n'
+  done <<<"${group_files[$key]}"
+  hits="$(printf '%s' "$hits" | sort -u | sed '/^$/d')"
   if [[ -n "$hits" ]]; then
     advisories=$((advisories + 1))
     while IFS= read -r line; do
@@ -103,9 +189,13 @@ if [[ "$checked" -eq 0 ]]; then
   exit 0
 fi
 
-echo "checked $checked file(s): $over over cap, $near near cap, $advisories with prose-globals advisories"
+summary="checked $checked repo(s): $over over cap, $near near cap, $advisories with prose-globals advisories"
+if [[ "$duplicates" -gt 0 ]]; then
+  summary="$summary ($duplicates duplicate checkout(s) folded in)"
+fi
+echo "$summary"
 if [[ "$over" -gt 0 ]]; then
-  echo "FAIL: $over file(s) over the ${CAP}-char cap are losing their tail to silent truncation" >&2
+  echo "FAIL: $over repo(s) over the ${CAP}-char cap are losing their tail to silent truncation" >&2
   exit 1
 fi
 echo "OK: every file is under the ${CAP}-char cap"

--- a/scripts/check-copilot-instructions.sh
+++ b/scripts/check-copilot-instructions.sh
@@ -82,24 +82,58 @@ PROSE_EXCLUDE='intentional|omit|exclud|not enforce|bot ignores|style linter|not 
 # git directory, which still collapses worktrees, and a directory that is not a repo at
 # all falls back to its own path so it is never merged with anything else.
 repo_identity() {
-  local repo="$1" url common
-  if url="$(git -C "$repo" remote get-url origin 2>/dev/null)" && [[ -n "$url" ]]; then
-    # Normalize so git@github.com:owner/repo.git and https://github.com/owner/repo
-    # resolve to the same identity.
-    url="${url%.git}"
-    url="${url#*://}"
-    url="${url#git@}"
-    url="${url/:/\/}"
-    printf 'origin:%s' "$(printf '%s' "$url" | tr '[:upper:]' '[:lower:]')"
+  local repo="$1" abs toplevel url host common
+
+  abs="$(cd "$repo" 2>/dev/null && pwd -P)" || abs=""
+
+  # A directory that merely SITS INSIDE a checkout must not borrow that checkout's
+  # identity. `git -C` searches upward, so both `remote get-url origin` and
+  # `--git-common-dir` answer for the enclosing repo, and two unrelated
+  # subdirectories would fold into one row. Only a directory that is itself a
+  # worktree root gets a git identity; that still includes linked worktrees and
+  # clones, which are exactly what we want folded. Everything else is its own path.
+  toplevel="$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null)" || toplevel=""
+  if [[ -z "$abs" || -z "$toplevel" || "$toplevel" != "$abs" ]]; then
+    printf 'path:%s' "${abs:-$repo}"
     return
   fi
-  if common="$(cd "$repo" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" &&
-    [[ -n "$common" ]]; then
-    [[ "$common" != /* ]] && common="$repo/$common"
+
+  if url="$(git -C "$repo" remote get-url origin 2>/dev/null)" && [[ -n "$url" ]]; then
+    url="${url%.git}"
+    if [[ "$url" == *://* ]]; then
+      # A real URL: host[:port]/path. Keep it as written apart from the scheme and
+      # any userinfo -- rewriting a colon here would mangle a port into a path
+      # segment.
+      url="${url#*://}"
+      url="${url#*@}"
+    else
+      # scp form, `[user@]host:owner/repo`, where the single colon separates host
+      # from path and does convert to a slash.
+      url="${url#*@}"
+      url="${url/:/\/}"
+    fi
+    # Case-fold only where case genuinely does not distinguish repos. GitHub
+    # owner/repo is case-insensitive, so git@github.com:Owner/Repo and
+    # https://github.com/owner/repo are one repo. Lowercasing every origin would
+    # instead merge distinct repos on a case-sensitive host.
+    host="${url%%/*}"
+    [[ "${host,,}" == "github.com" ]] && url="${url,,}"
+    printf 'origin:%s' "$url"
+    return
+  fi
+
+  if common="$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null)" && [[ -n "$common" ]]; then
+    # The same main worktree answers `.git` from inside itself and an absolute path
+    # from a linked worktree, and a trailing slash or relative argument leaves a
+    # third spelling. They have to be canonicalized or the fold silently stops
+    # working for exactly the no-origin worktrees this branch exists to catch.
+    [[ "$common" != /* ]] && common="$abs/$common"
+    common="$(cd "$common" 2>/dev/null && pwd -P)" || common="$abs/.git"
     printf 'gitdir:%s' "$common"
     return
   fi
-  printf 'path:%s' "$(cd "$repo" 2>/dev/null && pwd -P || printf '%s' "$repo")"
+
+  printf 'path:%s' "$abs"
 }
 
 # Collect every file first, then report one row per upstream repo. Reporting inside the

--- a/scripts/check-copilot-instructions.test.sh
+++ b/scripts/check-copilot-instructions.test.sh
@@ -76,6 +76,79 @@ mkdir -p "$tmp/empty"
 out="$("$guard" "$tmp/empty" 2>&1)"; rc=$?
 check "exit 0 when no file is present" test "$rc" -eq 0
 
+# The dedup cases (tools#77). ~/projects holds several checkouts of the same repo --
+# worktrees sharing one .git, and separate clones of one upstream -- and counting each
+# as its own repo made one over-cap file report as nine.
+mkrepo() { # mkrepo <name> <char-count> [origin-url]
+  local repo="$tmp/$1"
+  mkfile "$1" "$2"
+  git -C "$repo" init -q
+  [[ -n "${3:-}" ]] && git -C "$repo" remote add origin "$3"
+  git -C "$repo" add -A >/dev/null 2>&1
+  git -C "$repo" -c user.email=t@example.com -c user.name=t commit -qm init >/dev/null 2>&1
+}
+
+echo "=== two clones of one upstream count as one repo ==="
+mkrepo cloneA 4200 https://github.com/example/shared.git
+mkrepo cloneB 4200 git@github.com:Example/shared.git
+out="$("$guard" "$tmp/cloneA" "$tmp/cloneB" 2>&1)"; rc=$?
+check "still fails on the over-cap file" test "$rc" -eq 1
+check "counts one repo, not two" grep -q "checked 1 repo(s): 1 over cap" <<<"$out"
+check "names the folded checkouts" grep -q "same repo in 2 local checkouts" <<<"$out"
+check "reports the duplicate count" grep -q "1 duplicate checkout(s) folded in" <<<"$out"
+
+echo "=== a worktree is folded into its parent even with no origin ==="
+mkrepo solo 200
+git -C "$tmp/solo" worktree add -q "$tmp/solo-wt" -b wt >/dev/null 2>&1
+out="$("$guard" "$tmp/solo" "$tmp/solo-wt" 2>&1)"
+check "worktree does not double-count" grep -q "checked 1 repo(s)" <<<"$out"
+
+echo "=== distinct repos are still counted separately ==="
+mkrepo distinctA 200 https://github.com/example/one.git
+mkrepo distinctB 200 https://github.com/example/two.git
+out="$("$guard" "$tmp/distinctA" "$tmp/distinctB" 2>&1)"
+check "two upstreams stay two repos" grep -q "checked 2 repo(s)" <<<"$out"
+
+echo "=== non-repo directories are never merged together ==="
+mkfile plainA 200
+mkfile plainB 200
+out="$("$guard" "$tmp/plainA" "$tmp/plainB" 2>&1)"
+check "two plain directories stay two repos" grep -q "checked 2 repo(s)" <<<"$out"
+
+echo "=== the largest checkout wins, so a stale clone cannot hide an over-cap file ==="
+# Checkouts of one repo can sit at different commits. Reporting the smaller one would
+# turn the dedup into a way to miss the file that is actually truncating.
+mkrepo staleA 200 https://github.com/example/drift.git
+mkrepo staleB 4200 https://github.com/example/drift.git
+out="$("$guard" "$tmp/staleA" "$tmp/staleB" 2>&1)"; rc=$?
+check "over-cap sibling still fails the gate" test "$rc" -eq 1
+check "reports the larger file" grep -q "OVER CAP" <<<"$out"
+
+echo "=== folding the count must not fold the advisory coverage ==="
+# Only the smaller sibling restates a prose-style global. Scanning just the largest file
+# in the group would report nothing, so the dedup would have quietly narrowed the check.
+mkrepo advA 4200 https://github.com/example/cover.git
+mkfile advB 200 "Use sentence case, never Title Case."
+git -C "$tmp/advB" init -q
+git -C "$tmp/advB" remote add origin https://github.com/example/cover.git
+out="$("$guard" "$tmp/advA" "$tmp/advB" 2>&1)"
+check "still one repo" grep -q "checked 1 repo(s)" <<<"$out"
+check "advisory from the smaller checkout is still reported" \
+  grep -q "advisory: prose-style rule" <<<"$out"
+
+echo "=== identical checkouts report an advisory once, not once per checkout ==="
+mkrepo dupA 200 https://github.com/example/twice.git
+mkfile dupB 200 "Use sentence case, never Title Case."
+# Same content as dupA's file so the finding is genuinely identical, not just similar.
+cp "$tmp/dupA/.github/copilot-instructions.md" "$tmp/dupB/.github/copilot-instructions.md" 2>/dev/null || true
+printf 'Use sentence case, never Title Case.\n' >>"$tmp/dupA/.github/copilot-instructions.md"
+cp "$tmp/dupA/.github/copilot-instructions.md" "$tmp/dupB/.github/copilot-instructions.md"
+git -C "$tmp/dupB" init -q
+git -C "$tmp/dupB" remote add origin https://github.com/example/twice.git
+out="$("$guard" "$tmp/dupA" "$tmp/dupB" 2>&1)"
+check "identical advisory is not printed twice" \
+  test "$(grep -c 'advisory: prose-style rule' <<<"$out")" -eq 1
+
 echo
 echo "=== $pass passed, $fail failed ==="
 [[ $fail -eq 0 ]]

--- a/scripts/check-copilot-instructions.test.sh
+++ b/scripts/check-copilot-instructions.test.sh
@@ -149,6 +149,50 @@ out="$("$guard" "$tmp/dupA" "$tmp/dupB" 2>&1)"
 check "identical advisory is not printed twice" \
   test "$(grep -c 'advisory: prose-style rule' <<<"$out")" -eq 1
 
+echo "=== a plain directory inside a checkout does not borrow its origin ==="
+# `git -C` searches upward, so a directory that is merely nested in a repo answers
+# with the PARENT's origin and common git dir. Without a worktree-root check, two
+# unrelated subdirectories fold into one row and one of the files stops being counted.
+mkrepo nested 200 https://github.com/example/nested.git
+mkfile nested/inner1 200
+mkfile nested/inner2 200
+out="$("$guard" "$tmp/nested/inner1" "$tmp/nested/inner2" 2>&1)"
+check "nested plain directories are not folded by the parent's origin" \
+  grep -q "checked 2 repo(s)" <<<"$out"
+
+echo "=== a no-origin worktree folds even when the path is spelled differently ==="
+# `--git-common-dir` answers `.git` from inside the main worktree but an absolute
+# path from a linked one, and a trailing slash leaves a third spelling. Unless the
+# key is canonicalized, the fold quietly stops working for the no-origin case.
+mkrepo slashed 200
+git -C "$tmp/slashed" worktree add -q "$tmp/slashed-wt" -b wt >/dev/null 2>&1
+out="$("$guard" "$tmp/slashed/" "$tmp/slashed-wt" 2>&1)"
+check "trailing slash still folds the worktree" grep -q "checked 1 repo(s)" <<<"$out"
+
+echo "=== distinct non-GitHub origins are not merged by case folding ==="
+# GitHub owner/repo is case-insensitive, so folding case there is correct. Applying
+# it to every host merges repos that a case-sensitive server keeps separate.
+mkrepo caseA 200 https://git.example.com/Org/Repo.git
+mkrepo caseB 200 https://git.example.com/org/repo.git
+out="$("$guard" "$tmp/caseA" "$tmp/caseB" 2>&1)"
+check "case-distinct non-GitHub origins stay two repos" grep -q "checked 2 repo(s)" <<<"$out"
+
+echo "=== GitHub origins still fold across case and URL form ==="
+# The counterpart: the case folding that finding removes for other hosts must
+# survive for GitHub, or the original dedup regresses.
+mkrepo ghA 200 git@github.com:Example/Shared.git
+mkrepo ghB 200 https://github.com/example/shared
+out="$("$guard" "$tmp/ghA" "$tmp/ghB" 2>&1)"
+check "GitHub case and scp form still fold" grep -q "checked 1 repo(s)" <<<"$out"
+
+echo "=== an SSH URL with a port keeps the port out of the path ==="
+# Stripping the scheme then rewriting the first colon turns host:2222/org/repo into
+# host/2222/org/repo. Same-repo URLs written both ways must still agree.
+mkrepo portA 200 "ssh://git@git.example.com:2222/org/repo.git"
+mkrepo portB 200 "ssh://git@git.example.com:2222/org/repo"
+out="$("$guard" "$tmp/portA" "$tmp/portB" 2>&1)"
+check "a ported SSH origin folds with its .git-suffixed twin" grep -q "checked 1 repo(s)" <<<"$out"
+
 echo
 echo "=== $pass passed, $fail failed ==="
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
The cap guard scans every directory under `~/projects`, and several of those are the same repo seen twice: three worktrees sharing one `.git`, and six separate clones of one upstream. Each was counted on its own, so the summary line overstated the work by an order of magnitude.

Before, against the live `~/projects`:

```
checked 31 file(s): 12 over cap, 7 near cap, 23 with prose-globals advisories
FAIL: 12 file(s) over the 4000-char cap are losing their tail to silent truncation
```

After:

```
checked 15 repo(s): 2 over cap, 1 near cap, 7 with prose-globals advisories (16 duplicate checkout(s) folded in)
FAIL: 2 repo(s) over the 4000-char cap are losing their tail to silent truncation
```

Two is the real scope, and it matches what #77 already had to establish by re-measuring each file by hand. That hand re-measurement is the evidence the guard was reporting the wrong number: a check nobody can act on without redoing its work is not doing its job.

## How the fold works

Checkouts group by their `origin` URL, normalized so `git@github.com:owner/repo.git` and `https://github.com/owner/repo` resolve alike. That collapses worktrees and clones in one rule, since both point at the same remote. A checkout with no `origin` falls back to its shared git directory, which still collapses worktrees; a directory that is not a repo falls back to its own path, so it is never merged with anything else.

## Two things the fold deliberately does not do

- **It reports the largest file in a group, not the first one seen.** Checkouts sit at different commits. Reporting a smaller sibling would turn the dedup into a way to miss the file that is actually truncating, which is the opposite of the guard's purpose.
- **The advisory scan still reads every checkout**, collapsing identical findings. Folding the count must not fold the coverage: a sibling on a different commit can restate prose-style globals the representative file does not.

## Tests

`scripts/check-copilot-instructions.test.sh` goes from 11 to 23 assertions, covering two clones of one upstream, a worktree with no origin, distinct upstreams staying distinct, non-repo directories never merging, the largest-file rule, advisory coverage across a folded sibling, and identical advisories printing once. Six of the new assertions were confirmed failing against the pre-change script. `shellcheck` clean.

Scope note: this fixes the guard's accounting only. The two genuinely over-cap files (`houseofjawn-dashboard` at 5170, `ccm` at 4450) live in their own repos and stay open on #77.

Refs #77. wake-20260724T1705-33b7a3